### PR TITLE
Fix calibration I/O bug

### DIFF
--- a/software/o_c_REV/APP_SETTINGS.ino
+++ b/software/o_c_REV/APP_SETTINGS.ino
@@ -126,7 +126,8 @@ size_t Settings_save(void *storage) {return 0;}
 size_t Settings_restore(const void *storage) {return 0;}
 
 void Settings_isr() {
-	return Settings_instance.BaseController();
+// skip the Controller to avoid I/O conflict with Calibration
+  return;
 }
 
 void Settings_handleAppEvent(OC::AppEvent event) {


### PR DESCRIPTION
Calibration is broken in v1.6.4 due to refactoring. This should fix it. Currently untested.