### PR TITLE
Fix SPI startup on Teensy 4.1

### DIFF
--- a/software/o_c_REV/OC_DAC.cpp
+++ b/software/o_c_REV/OC_DAC.cpp
@@ -85,11 +85,18 @@ void DAC::Init(CalibrationData *calibration_data) {
     SPIFIFO.begin(DAC_CS, SPICLOCK_30MHz, SPI_MODE0);  
 
 #elif defined(__IMXRT1062__)
+  #if defined(ARDUINO_TEENSY40)
   SPI.begin();
   IOMUXC_SW_MUX_CTL_PAD_GPIO_B0_00 = 3; // DAC CS pin controlled by SPI
-  #if defined(ARDUINO_TEENSY41)
-  // if (DAC8568_Uses_SPI), assume DAC8568_Vref_enable() already called by
-  // main program startup, so we don't need to do any more hardware init
+  #elif defined(ARDUINO_TEENSY41)
+  if (DAC8568_Uses_SPI) {
+    // Assume DAC8568_Vref_enable() already called by  main program startup,
+    // so we don't need to do any more hardware init, and calling SPI.begin()
+    // again could cause problems.
+  } else {
+    SPI.begin();
+    IOMUXC_SW_MUX_CTL_PAD_GPIO_B0_00 = 3; // DAC CS pin controlled by SPI
+  }
   if (ADC33131D_Uses_FlexIO) {
     // ADC33131D wants pin 12 for data input, but SPI.begin() takes it away
     // reconfigure pin mux to return pin 12 control to FlexIO


### PR DESCRIPTION
Opps, the changes I made to turn on DAC8586 Vref early (which requires using SPI) messed up SPI startup.

This change makes the 3 cases for Teensy 4.x separate, even though 2 of them are identical, so it's easy to see how SPI startup differs depending on which board we're targeting.