### PR TITLE
Update custom build github action to avoid breaking as GitHub end-of-lifes Node.js 16 support

### DIFF
--- a/.github/workflows/custom.yml
+++ b/.github/workflows/custom.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: phazerville
 
@@ -23,13 +23,13 @@ jobs:
         echo "CUSTOM_BUILD_FLAGS=$(python software/res/parse_build_request.py)" >> $GITHUB_ENV
 
     - name: Cache PlatformIO
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.platformio
         key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
 
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
         cache: 'pip'
@@ -45,7 +45,7 @@ jobs:
         pio run -e custom
 
     - name: Copy artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: o_C-${{env.OC_ARTIFACT_TAG}}
         path: software/.pio/build/*/*.hex

--- a/.github/workflows/custom.yml
+++ b/.github/workflows/custom.yml
@@ -29,7 +29,7 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
         cache: 'pip'


### PR DESCRIPTION
I did [a custom build recently](https://github.com/djphazer/O_C-Phazerville/actions/runs/8167688458) and I noticed a warning:

> 1 warning
Build Custom Firmware
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/cache@v3, actions/setup-python@v3, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

From the github blog linked there:

> Node 16 has reached its [end of life](https://github.com/nodejs/Release/#end-of-life-releases), prompting us to initiate its deprecation process for GitHub Actions. Our plan is to transition all actions to run on Node 20 by Spring 2024.

So it sounds like the Phazerville custom build workflow is going to break in the coming months if we don't upgrade some GitHub Actions.

This PR upgrades said Actions to keep everything running smoothly. Note that this simply updates some GitHub/Microsoft-maintained automation scripts for the github.com platform, and doesn't affect the python version or anything with potential impact. Everything should be fully backward compatible, and it's not like we have a choice: This is a forced upgrade. 

I tested it here: https://github.com/adamjmurray/O_C-Phazerville/discussions/1

I had done the same build over in the main repository here and the resulting build artifact was the same size before and after these changes. I'm about to go install the final build on my O_C hardware. I'll give a shout if anything seems wrong.

**Note: The same changes will need to be applied to [.github/workflows/firmware.yml](https://github.com/djphazer/O_C-Phazerville/blob/phazerville/.github/workflows/firmware.yml). I am not setup to test that workflow right now, so I didn't include its fix in this PR.**