### PR TITLE
Global Sequence Length for MiniSeq, and SwitchSeq tweaks

### DIFF
--- a/software/src/applets/SwitchSeq.h
+++ b/software/src/applets/SwitchSeq.h
@@ -98,7 +98,6 @@ public:
     void View()
     {
         gfxHeader(applet_name());
-        // DrawScale();
         DrawMode();
         DrawIndicator();
     }
@@ -134,22 +133,17 @@ public:
     }
 
 protected:
-    // TODO: global scale
-    // TODO: help
-
     void SetHelp()
     {
         //                               "------------------" <-- Size Guide
         help[HEMISPHERE_HELP_DIGITALS] = "1=Clock,2=Reset";
-        help[HEMISPHERE_HELP_CVS] = "CV Ch1,Ch2";
-        help[HEMISPHERE_HELP_OUTS] = "A=Out1,B=Out1";
-        help[HEMISPHERE_HELP_ENCODER] = "Change Mode,Seq";
+        help[HEMISPHERE_HELP_CVS]      = "CV Ch1,Ch2";
+        help[HEMISPHERE_HELP_OUTS]     = "A=Out1,B=Out1";
+        help[HEMISPHERE_HELP_ENCODER]  = "Change Mode,Seq";
         //                               "------------------" <-- Size Guide
     }
 
 private:
-    // TODO: reset vs. 2nd clock mode
-
     // Modes
     int mode[2] = {0, -1}; // 0-3: sequences 0-3 with CV octave transpose (0, 1, or 2 octaves). -1: CV picks sequence, -2 = CV quantize mode, -3 = pick random sequence
     int cv[2] = {0, 0};    // 0 -> HEMISPHERE_MAX_CV. RAND mode writes to this (and over-writes input CV)
@@ -159,12 +153,6 @@ private:
 
     // UI
     int cursor = 0;
-
-    void DrawScale()
-    {
-        gfxPrint(0, 15, OC::Strings::note_names_unpadded[GetRootNote(0)]); // we show the scale but can't change it.
-        gfxPrint(8, 15, OC::scale_names_short[GetScale(0)]);
-    }
 
     void DrawMode()
     {
@@ -177,21 +165,19 @@ private:
             }
             else if (mode[ch] == PICK_MODE)
             {
-                gfxPrint(0, ypos, "PICK");
+                gfxPrint(0, ypos, "PCK");
             }
             else if (mode[ch] == RAND_MODE)
             {
-                gfxPrint(0, ypos, "RAND");
+                gfxPrint(0, ypos, "RNG");
             }
             else if (mode[ch] == QUAN_MODE)
             {
-                gfxPrint(0, ypos, "QUAN");
+                gfxPrint(0, ypos, "QNT");
             }
 
             int notenum = MIDIQuantizer::NoteNumber(ValueForChannel(ch));
-            //int notenum = GetLatestNoteNumber(ch);
-            gfxPrint(0, ypos + 10, midi_note_numbers[notenum]);
-            //gfxPrintfn(0, ypos + 10, 4, "%03d", ValueForChannel(ch) / 128);
+            gfxPrintfn(0, ypos + 10, 4, "%3s", midi_note_numbers[notenum]);
 
             // cursor when not picking sequence directly
             if (cursor == ch && mode[ch] < 0)
@@ -206,7 +192,7 @@ private:
         // step
         for (int i = 0; i < 4; i++)
         {
-          gfxPrintfn(43, 25 + (10 * i), 3, "%03d", (miniseq[i].GetNote() + 64));
+          gfxPrintfn(6*7 + 1, 25 + (10 * i), 3, "%3d", miniseq[i].GetNote() + 64);
         }
 
         // arrow indicators
@@ -215,7 +201,7 @@ private:
             int seq = SequenceForChannel(ch);
             if (seq >= 0)
             {
-                int x = 28 + (6 * ch);
+                int x = (6*5) - 2 + (6 * ch); 
                 int y = 25 + (10 * seq);
                 if (mode[ch] >= 0)
                 {

--- a/software/src/applets/SwitchSeq.h
+++ b/software/src/applets/SwitchSeq.h
@@ -55,6 +55,8 @@ public:
       for (int i = 0; i < 4; ++i) {
         miniseq[i].SetPattern(i);
       }
+      Out(0, 0); 
+      Out(1, 0);
     }
 
     void Controller()

--- a/software/src/applets/SwitchSeq.h
+++ b/software/src/applets/SwitchSeq.h
@@ -69,11 +69,12 @@ public:
         // reset
         if (Clock(1))
         {
+            StartADCLag(1);
             Reset();
         }
 
         // only make changes on a clock'd signal.
-        if (EndOfADCLag(0))
+        if (EndOfADCLag(0) || EndOfADCLag(1))
         {
             ForEachChannel(ch)
             {

--- a/software/src/applets/SwitchSeq.h
+++ b/software/src/applets/SwitchSeq.h
@@ -88,9 +88,8 @@ public:
                 {
                     cv[ch] = In(ch);
                 }
-                int32_t pitch = ValueForChannel(ch);
-                int32_t quantized = Quantize(ch, pitch);
-                Out(ch, quantized);
+                int32_t cv = ValueForChannel(ch);
+                Out(ch, cv);
             }
         }
     }
@@ -266,23 +265,25 @@ private:
         return play_note;
     }
 
-    // get pre-quantize CV
+    // get quantized output as cv
     int ValueForChannel(int ch)
     {
+        int value = 0;
         int seq = SequenceForChannel(ch);
         if (seq >= 0)
         {
-            int value = QuantizerLookup(ch, NoteForSequence(seq));
+            value = QuantizerLookup(ch, NoteForSequence(seq));
             if (mode[ch] >= 0)
             {
                 value = value + (Proportion(cv[ch], PP_MAX_INPUT_CV, OCTAVE_RANGE) * OCTAVE_1);
             }
-            return value;
         }
         else // QUAN mode... or we were not able to find a sequence.
         {
-            int reduced = Proportion(cv[ch], PP_MAX_INPUT_CV, OCTAVE_RANGE * OCTAVE_1);
-            return reduced;
+            value = Proportion(cv[ch], PP_MAX_INPUT_CV, OCTAVE_RANGE * OCTAVE_1);
         }
+
+        int quantized = Quantize(ch, value);
+        return quantized;
     }
 };

--- a/software/src/applets/SwitchSeq.h
+++ b/software/src/applets/SwitchSeq.h
@@ -192,7 +192,8 @@ private:
         // step
         for (int i = 0; i < 4; i++)
         {
-          gfxPrintfn(6*7 + 1, 25 + (10 * i), 3, "%3d", miniseq[i].GetNote() + 64);
+          int note = NoteForSequence(i);
+          gfxPrintfn(6*7 + 1, 25 + (10 * i), 3, "%3d", note);
         }
 
         // arrow indicators
@@ -257,16 +258,24 @@ private:
         return seq;
     }
 
+    // returns the index for the quantizer. Must be used in QuantizerLookup.
+    int NoteForSequence(int seq)
+    {
+        int play_note = miniseq[seq].GetNote() + 64;
+        CONSTRAIN(play_note, 0, 127);
+        return play_note;
+    }
+
     // get pre-quantize CV
     int ValueForChannel(int ch)
     {
         int seq = SequenceForChannel(ch);
         if (seq >= 0)
         {
-            int value = QuantizerLookup(ch, miniseq[seq].GetNote() + 64);
+            int value = QuantizerLookup(ch, NoteForSequence(seq));
             if (mode[ch] >= 0)
             {
-                value = value + (Proportion(cv[ch], PP_MAX_INPUT_CV, OCTAVE_RANGE + 1) * OCTAVE_1);
+                value = value + (Proportion(cv[ch], PP_MAX_INPUT_CV, OCTAVE_RANGE) * OCTAVE_1);
             }
             return value;
         }


### PR DESCRIPTION
These are all the tweaks I have made since opening https://github.com/djphazer/O_C-Phazerville/pull/67. I rebased on top of the current beta version and discovered you already merged my code! Thanks!

Tweaks:
- Add `global_settings.pattern_lengths` for use with MiniSeq. Global settings are now right at their limit in terms of size. SwitchSeq reads from it, and Seq32 writes to it. (https://github.com/djphazer/O_C-Phazerville/pull/74/commits/f50f20de00962f34e2c202ecfa056152fb4715e7)
- In my last version I used a hack to fix Proportion for negative values. I found a better way: do all math using positive numbers, but convert it to a negative just before returning. This makes the rounding logic "mirrored" for positive and negative numbers.
- Tweak the UI of SwitchSeq to account for the new behaviour. This basically amounts to editing spacing, tweaking which kinds of values are shown, introducing a helper function, and removing some dead code.

For review, each commit is self-contained. It will be easier to review each commit individually, then look at the whole thing. The largest change, global sequence lengths, is fully inside of this one commit: https://github.com/djphazer/O_C-Phazerville/pull/74/commits/f50f20de00962f34e2c202ecfa056152fb4715e7

I want to keep the first two commits separated, but the "tweaking" of SwitchSeq can be squashed before merging. 
