### PR TITLE
MIDIOut cc cache

### DIFF
--- a/software/src/applets/hMIDIOut.h
+++ b/software/src/applets/hMIDIOut.h
@@ -109,10 +109,13 @@ public:
                 // Modulation wheel
                 if (function == HEM_MIDI_CC_IN) {
                     int value = ProportionCV(In(1), 127);
-                    usbMIDI.sendControlChange(1, value, channel + 1);
-                    usbMIDI.send_now();
-                    UpdateLog(HEM_MIDI_CC, value, 0);
-                    last_tick = OC::CORE::ticks;
+                    if (value != last_cc) {
+                      usbMIDI.sendControlChange(1, value, channel + 1);
+                      usbMIDI.send_now();
+                      last_cc = value;
+                      UpdateLog(HEM_MIDI_CC, value, 0);
+                      last_tick = OC::CORE::ticks;
+                    }
                 }
 
                 // Aftertouch
@@ -217,6 +220,7 @@ private:
     int last_note; // Last MIDI note number awaiting not off
     int last_velocity;
     int last_channel; // The last Note On channel, just in case the channel is changed before release
+    int last_cc; // Last modulation wheel sent
     bool gated; // The most recent gate status
     bool legato_on; // The note handler may currently respond to legato note changes
     int last_tick; // Most recent MIDI message sent

--- a/software/src/applets/hMIDIOut.h
+++ b/software/src/applets/hMIDIOut.h
@@ -121,20 +121,26 @@ public:
                 // Aftertouch
                 if (function == HEM_MIDI_AT_IN) {
                     int value = ProportionCV(In(1), 127);
-                    usbMIDI.sendAfterTouch(value, channel + 1);
-                    usbMIDI.send_now();
-                    UpdateLog(HEM_MIDI_AFTERTOUCH, value, 0);
-                    last_tick = OC::CORE::ticks;
+                    if (value != last_at) {
+                      usbMIDI.sendAfterTouch(value, channel + 1);
+                      usbMIDI.send_now();
+                      last_at = value;
+                      UpdateLog(HEM_MIDI_AFTERTOUCH, value, 0);
+                      last_tick = OC::CORE::ticks;
+                    }
                 }
 
                 // Pitch Bend
                 if (function == HEM_MIDI_PB_IN) {
                     uint16_t bend = Proportion(In(1) + HEMISPHERE_3V_CV, HEMISPHERE_3V_CV * 2, 16383);
                     bend = constrain(bend, 0, 16383);
-                    usbMIDI.sendPitchBend(bend, channel + 1);
-                    usbMIDI.send_now();
-                    UpdateLog(HEM_MIDI_PITCHBEND, bend - 8192, 0);
-                    last_tick = OC::CORE::ticks;
+                    if (bend != last_bend) {
+                      usbMIDI.sendPitchBend(bend, channel + 1);
+                      usbMIDI.send_now();
+                      last_bend = bend;
+                      UpdateLog(HEM_MIDI_PITCHBEND, bend - 8192, 0);
+                      last_tick = OC::CORE::ticks;
+                    }
                 }
             }
         }
@@ -221,6 +227,8 @@ private:
     int last_velocity;
     int last_channel; // The last Note On channel, just in case the channel is changed before release
     int last_cc; // Last modulation wheel sent
+    int last_at; // Last aftertouch sent
+    int last_bend; // Last pitch bend sent
     bool gated; // The most recent gate status
     bool legato_on; // The note handler may currently respond to legato note changes
     int last_tick; // Most recent MIDI message sent


### PR DESCRIPTION
Hi. This is an attempt to address #83 

With the precisely same two-module patch of a single LFO into o_C CV2, here is the log from MIDIOut before:

https://github.com/djphazer/O_C-Phazerville/assets/879300/f05daa36-746b-47e8-9fba-3b29ab6094ad

and after:

https://github.com/djphazer/O_C-Phazerville/assets/879300/10f6a8cf-2d22-4647-ac89-9a428594e7e9

Notice that redundant values (e.g. value 127) are no longer sent.

I cannot yet say for sure whether it actually _fixes_ choking issues, but at least it seems no redundant messages are pushed. Are there reasons where redundant messages would be good? All I can think of is situations where one MIDI cc is changed by two sources, say from o_C and a slider too. With caching, o_C would not longer force send the messages. Is this an issue?

Are there edge cases to think about? And does the AT and PB look sensible? They seem to work as intended but I am not actually familiar with these functions of MIDI.

Also: did I make this change against a weird branch?  I am not super sure which branch I should contribute to but I use 1.7 so I did that one.

PS. Thanks for Phazerville.