### PR TITLE
updated MIDI input handling and user interface. added features and fixed a couple issues

### DIFF
--- a/software/src/APP_HEMISPHERE.h
+++ b/software/src/APP_HEMISPHERE.h
@@ -463,16 +463,23 @@ public:
                     case HEM_MIDI_VEL_OUT:
                     case HEM_MIDI_AT_OUT:
                     case HEM_MIDI_PB_OUT:
-                    case HEM_MIDI_POLY1_OUT:
-                    case HEM_MIDI_POLY2_OUT:
-                    case HEM_MIDI_POLY3_OUT:
-                    case HEM_MIDI_POLY4_OUT:
+                    case HEM_MIDI_NOTE_POLY1_OUT:
+                    case HEM_MIDI_NOTE_POLY2_OUT:
+                    case HEM_MIDI_NOTE_POLY3_OUT:
+                    case HEM_MIDI_NOTE_POLY4_OUT:
+                    case HEM_MIDI_NOTE_MIN_OUT:
+                    case HEM_MIDI_NOTE_MAX_OUT:
+                    case HEM_MIDI_NOTE_PEDAL_OUT:
+                    case HEM_MIDI_NOTE_INV_OUT:
                         HS::frame.inputs[chan] += HS::frame.MIDIState.outputs[chan];
                         break;
                     case HEM_MIDI_GATE_OUT:
+                    case HEM_MIDI_GATE_INV_OUT:
                         HS::frame.gate_high[chan] |= (HS::frame.MIDIState.outputs[chan] > (12 << 7));
                         break;
                     case HEM_MIDI_TRIG_OUT:
+                    case HEM_MIDI_TRIG_1ST_OUT:
+                    case HEM_MIDI_TRIG_ALWAYS_OUT:
                     case HEM_MIDI_CLOCK_OUT:
                     case HEM_MIDI_START_OUT:
                         HS::frame.clocked[chan] |= HS::frame.MIDIState.trigout_q[chan];

--- a/software/src/APP_HEMISPHERE.h
+++ b/software/src/APP_HEMISPHERE.h
@@ -463,6 +463,10 @@ public:
                     case HEM_MIDI_VEL_OUT:
                     case HEM_MIDI_AT_OUT:
                     case HEM_MIDI_PB_OUT:
+                    case HEM_MIDI_POLY1_OUT:
+                    case HEM_MIDI_POLY2_OUT:
+                    case HEM_MIDI_POLY3_OUT:
+                    case HEM_MIDI_POLY4_OUT:
                         HS::frame.inputs[chan] += HS::frame.MIDIState.outputs[chan];
                         break;
                     case HEM_MIDI_GATE_OUT:

--- a/software/src/APP_HEMISPHERE.h
+++ b/software/src/APP_HEMISPHERE.h
@@ -471,7 +471,11 @@ public:
                     case HEM_MIDI_VEL2_OUT:
                     case HEM_MIDI_VEL3_OUT:
                     case HEM_MIDI_VEL4_OUT:
-                    case HEM_MIDI_AT_OUT:
+                    case HEM_MIDI_AT_CHAN_OUT:
+                    case HEM_MIDI_AT_KEY1_OUT:
+                    case HEM_MIDI_AT_KEY2_OUT:
+                    case HEM_MIDI_AT_KEY3_OUT:
+                    case HEM_MIDI_AT_KEY4_OUT:
                     case HEM_MIDI_PB_OUT:
                         HS::frame.inputs[chan] += HS::frame.MIDIState.outputs[chan];
                         break;

--- a/software/src/APP_HEMISPHERE.h
+++ b/software/src/APP_HEMISPHERE.h
@@ -460,10 +460,6 @@ public:
                     switch (HS::frame.MIDIState.function[chan]) {
                     case HEM_MIDI_CC_OUT:
                     case HEM_MIDI_NOTE_OUT:
-                    case HEM_MIDI_VEL_OUT:
-                    case HEM_MIDI_AT_OUT:
-                    case HEM_MIDI_PB_OUT:
-                    case HEM_MIDI_NOTE_POLY1_OUT:
                     case HEM_MIDI_NOTE_POLY2_OUT:
                     case HEM_MIDI_NOTE_POLY3_OUT:
                     case HEM_MIDI_NOTE_POLY4_OUT:
@@ -471,6 +467,12 @@ public:
                     case HEM_MIDI_NOTE_MAX_OUT:
                     case HEM_MIDI_NOTE_PEDAL_OUT:
                     case HEM_MIDI_NOTE_INV_OUT:
+                    case HEM_MIDI_VEL_OUT:
+                    case HEM_MIDI_VEL2_OUT:
+                    case HEM_MIDI_VEL3_OUT:
+                    case HEM_MIDI_VEL4_OUT:
+                    case HEM_MIDI_AT_OUT:
+                    case HEM_MIDI_PB_OUT:
                         HS::frame.inputs[chan] += HS::frame.MIDIState.outputs[chan];
                         break;
                     case HEM_MIDI_GATE_OUT:

--- a/software/src/APP_MIDI.h
+++ b/software/src/APP_MIDI.h
@@ -750,7 +750,7 @@ private:
                 }
             }
 
-            if (message == HEM_MIDI_AFTERTOUCH && in_fn == MIDI_IN_AFTERTOUCH && in_ch == channel) {
+            if (message == HEM_MIDI_AFTERTOUCH_CHANNEL && in_fn == MIDI_IN_AFTERTOUCH && in_ch == channel) {
                 // Send aftertouch to CV
                 Out(ch, Proportion(data1, 127, HSAPPLICATION_5V));
                 UpdateLog(1, ch, 3, in_ch, data1, data2);

--- a/software/src/APP_QUADRANTS.h
+++ b/software/src/APP_QUADRANTS.h
@@ -407,10 +407,6 @@ public:
                     switch (HS::frame.MIDIState.function[chan]) {
                     case HEM_MIDI_CC_OUT:
                     case HEM_MIDI_NOTE_OUT:
-                    case HEM_MIDI_VEL_OUT:
-                    case HEM_MIDI_AT_OUT:
-                    case HEM_MIDI_PB_OUT:
-                    case HEM_MIDI_NOTE_POLY1_OUT:
                     case HEM_MIDI_NOTE_POLY2_OUT:
                     case HEM_MIDI_NOTE_POLY3_OUT:
                     case HEM_MIDI_NOTE_POLY4_OUT:
@@ -418,6 +414,12 @@ public:
                     case HEM_MIDI_NOTE_MAX_OUT:
                     case HEM_MIDI_NOTE_PEDAL_OUT:
                     case HEM_MIDI_NOTE_INV_OUT:
+                    case HEM_MIDI_VEL_OUT:
+                    case HEM_MIDI_VEL2_OUT:
+                    case HEM_MIDI_VEL3_OUT:
+                    case HEM_MIDI_VEL4_OUT:
+                    case HEM_MIDI_AT_OUT:
+                    case HEM_MIDI_PB_OUT:
                         HS::frame.inputs[chan] += HS::frame.MIDIState.outputs[chan];
                         break;
                     case HEM_MIDI_GATE_OUT:

--- a/software/src/APP_QUADRANTS.h
+++ b/software/src/APP_QUADRANTS.h
@@ -410,6 +410,10 @@ public:
                     case HEM_MIDI_VEL_OUT:
                     case HEM_MIDI_AT_OUT:
                     case HEM_MIDI_PB_OUT:
+                    case HEM_MIDI_POLY1_OUT:
+                    case HEM_MIDI_POLY2_OUT:
+                    case HEM_MIDI_POLY3_OUT:
+                    case HEM_MIDI_POLY4_OUT:
                         HS::frame.inputs[chan] += HS::frame.MIDIState.outputs[chan];
                         break;
                     case HEM_MIDI_GATE_OUT:
@@ -1060,7 +1064,7 @@ private:
         const char * cursor_mode_name[3] = { "modal", "modal+wrap" };
         gfxPrint(1, 35, "Cursor:  ");
         gfxPrint(cursor_mode_name[HS::cursor_wrap]);
-        
+
         switch (config_cursor) {
         case TRIG_LENGTH:
             gfxCursor(80, 23, 24);

--- a/software/src/APP_QUADRANTS.h
+++ b/software/src/APP_QUADRANTS.h
@@ -418,7 +418,11 @@ public:
                     case HEM_MIDI_VEL2_OUT:
                     case HEM_MIDI_VEL3_OUT:
                     case HEM_MIDI_VEL4_OUT:
-                    case HEM_MIDI_AT_OUT:
+                    case HEM_MIDI_AT_CHAN_OUT:
+                    case HEM_MIDI_AT_KEY1_OUT:
+                    case HEM_MIDI_AT_KEY2_OUT:
+                    case HEM_MIDI_AT_KEY3_OUT:
+                    case HEM_MIDI_AT_KEY4_OUT:
                     case HEM_MIDI_PB_OUT:
                         HS::frame.inputs[chan] += HS::frame.MIDIState.outputs[chan];
                         break;

--- a/software/src/APP_QUADRANTS.h
+++ b/software/src/APP_QUADRANTS.h
@@ -410,16 +410,23 @@ public:
                     case HEM_MIDI_VEL_OUT:
                     case HEM_MIDI_AT_OUT:
                     case HEM_MIDI_PB_OUT:
-                    case HEM_MIDI_POLY1_OUT:
-                    case HEM_MIDI_POLY2_OUT:
-                    case HEM_MIDI_POLY3_OUT:
-                    case HEM_MIDI_POLY4_OUT:
+                    case HEM_MIDI_NOTE_POLY1_OUT:
+                    case HEM_MIDI_NOTE_POLY2_OUT:
+                    case HEM_MIDI_NOTE_POLY3_OUT:
+                    case HEM_MIDI_NOTE_POLY4_OUT:
+                    case HEM_MIDI_NOTE_MIN_OUT:
+                    case HEM_MIDI_NOTE_MAX_OUT:
+                    case HEM_MIDI_NOTE_PEDAL_OUT:
+                    case HEM_MIDI_NOTE_INV_OUT:
                         HS::frame.inputs[chan] += HS::frame.MIDIState.outputs[chan];
                         break;
                     case HEM_MIDI_GATE_OUT:
+                    case HEM_MIDI_GATE_INV_OUT:
                         HS::frame.gate_high[chan] |= (HS::frame.MIDIState.outputs[chan] > (12 << 7));
                         break;
                     case HEM_MIDI_TRIG_OUT:
+                    case HEM_MIDI_TRIG_1ST_OUT:
+                    case HEM_MIDI_TRIG_ALWAYS_OUT:
                     case HEM_MIDI_CLOCK_OUT:
                     case HEM_MIDI_START_OUT:
                         HS::frame.clocked[chan] |= HS::frame.MIDIState.trigout_q[chan];

--- a/software/src/HSIOFrame.h
+++ b/software/src/HSIOFrame.h
@@ -232,8 +232,27 @@ typedef struct IOFrame {
                     semitone_mask[ch] = semitone_mask[ch] | (1u << (data1 % 12));
 
                     // Should this message go out on this channel?
-                    if (function[ch] == HEM_MIDI_NOTE_OUT)
+                    if (function[ch] == HEM_MIDI_NOTE_OUT || function[ch] == HEM_MIDI_POLY1_OUT) {
                         outputs[ch] = MIDIQuantizer::CV(note_buffer[m_ch].back().note);
+                    }
+                    if (function[ch] == HEM_MIDI_POLY2_OUT) {
+                        if (note_buffer[m_ch].size() > 1)
+                            outputs[ch] = MIDIQuantizer::CV(note_buffer[m_ch].at(note_buffer[m_ch].size()-2).note);
+                        else
+                            outputs[ch] = MIDIQuantizer::CV(note_buffer[m_ch].front().note);
+                    }
+                    if (function[ch] == HEM_MIDI_POLY3_OUT) {
+                        if (note_buffer[m_ch].size() > 2)
+                            outputs[ch] = MIDIQuantizer::CV(note_buffer[m_ch].at(note_buffer[m_ch].size()-3).note);
+                        else
+                            outputs[ch] = MIDIQuantizer::CV(note_buffer[m_ch].front().note);
+                    }
+                    if (function[ch] == HEM_MIDI_POLY4_OUT) {
+                        if (note_buffer[m_ch].size() > 3)
+                            outputs[ch] = MIDIQuantizer::CV(note_buffer[m_ch].at(note_buffer[m_ch].size()-4).note);
+                        else
+                            outputs[ch] = MIDIQuantizer::CV(note_buffer[m_ch].front().note);
+                    }
 
                     if (function[ch] == HEM_MIDI_TRIG_OUT)
                         trigout_q[ch] = 1;
@@ -251,9 +270,29 @@ typedef struct IOFrame {
                 case usbMIDI.NoteOff:
                     semitone_mask[ch] = semitone_mask[ch] & ~(1u << (data1 % 12));
 
-                    if (function[ch] == HEM_MIDI_NOTE_OUT)
-                        if (note_buffer[m_ch].size() > 0) // don't update output when last note is released
+                    if (note_buffer[m_ch].size() > 0) { // don't update output when last note is released
+                        if (function[ch] == HEM_MIDI_NOTE_OUT || function[ch] == HEM_MIDI_POLY1_OUT) {
                             outputs[ch] = MIDIQuantizer::CV(note_buffer[m_ch].back().note);
+                        }
+                        if (function[ch] == HEM_MIDI_POLY2_OUT) {
+                            if (note_buffer[m_ch].size() < 2)
+                                outputs[ch] = MIDIQuantizer::CV(note_buffer[m_ch].front().note);
+                            else
+                                outputs[ch] = MIDIQuantizer::CV(note_buffer[m_ch].at(note_buffer[m_ch].size()-2).note);
+                        }
+                        if (function[ch] == HEM_MIDI_POLY3_OUT) {
+                            if (note_buffer[m_ch].size() < 3)
+                                outputs[ch] = MIDIQuantizer::CV(note_buffer[m_ch].front().note);
+                            else
+                                outputs[ch] = MIDIQuantizer::CV(note_buffer[m_ch].at(note_buffer[m_ch].size()-3).note);
+                        }
+                        if (function[ch] == HEM_MIDI_POLY4_OUT) {
+                            if (note_buffer[m_ch].size() < 4)
+                                outputs[ch] = MIDIQuantizer::CV(note_buffer[m_ch].front().note);
+                            else
+                                outputs[ch] = MIDIQuantizer::CV(note_buffer[m_ch].at(note_buffer[m_ch].size()-4).note);
+                        }
+                    }
 
                     // turn gate off only when all notes are off
                     if (!(note_buffer[m_ch].size() > 0)) {

--- a/software/src/HSIOFrame.h
+++ b/software/src/HSIOFrame.h
@@ -64,10 +64,11 @@ typedef struct IOFrame {
         uint16_t semitone_mask[ADC_CHANNEL_LAST]; // which notes are currently on
 
         // MIDI input stuff handled by MIDIIn applet
-        std::vector<MIDINoteData> note_buffer[16]; // note buffer for polyphonic input. one for each midi channel
+        std::vector<MIDINoteData> note_buffer[16]; // note buffer for polyphonic input. one for each MIDI channel
         int outputs[DAC_CHANNEL_LAST]; // translated CV values
         bool trigout_q[DAC_CHANNEL_LAST];
         int last_midi_channel = 0; // for MIDI In activity monitor
+        uint16_t sustain_latch; // each bit is a MIDI channel's sustain state
 
         void RemoveNoteData(std::vector<MIDINoteData> &buffer, int note) {
             buffer.erase(
@@ -93,10 +94,15 @@ typedef struct IOFrame {
             if (note_buffer[c].size() == 0) note_buffer[c].shrink_to_fit(); // free up memory when MIDI is not used
         }
 
-        void NoteStackClear() {
-            for (int c = 0; c < 16; ++c) {
-                note_buffer[c].clear();
-                note_buffer[c].shrink_to_fit();
+        void ClearNoteStack(int ch = -1) {
+            if (ch > 0) {
+                note_buffer[ch].clear();
+                note_buffer[ch].shrink_to_fit();
+            } else { // clear on all channels if no args passed
+                for (int c = 0; c < 16; ++c) {
+                    note_buffer[c].clear();
+                    note_buffer[c].shrink_to_fit();
+                }
             }
         }
 
@@ -134,6 +140,22 @@ typedef struct IOFrame {
 
         int GetVel(std::vector<MIDINoteData> &buffer, int n) {
             return buffer.at(buffer.size()-n).vel;
+        }
+
+        void ClearSustainLatch(int m_ch = -1) {
+            if (m_ch > 0) sustain_latch &= ~(1 << m_ch);
+            else { // clear on all channels if no args passed
+                for (int c = 0; c < 16; ++c)
+                    sustain_latch &= ~(1 << c);
+            }
+        }
+
+        void SetSustainLatch(int m_ch) {
+            sustain_latch |= (1 << m_ch);
+        }
+
+        bool CheckSustainLatch(int m_ch) {
+            return sustain_latch & (1 << m_ch);
         }
 
         // Clock/Start/Stop are handled by ClockSetup applet
@@ -231,7 +253,12 @@ typedef struct IOFrame {
                 stop_q = 1;
                 clock_run = false;
                 // a way to reset stuck notes
-                NoteStackClear();
+                ClearNoteStack();
+                ClearSustainLatch();
+                // for (int c = 0; c < 4; ++c) {
+                //     outputs[c] = 0;
+                //     trigout_q[c] = 0;
+                // }
                 return;
                 break;
 
@@ -283,11 +310,12 @@ typedef struct IOFrame {
                             case HEM_MIDI_NOTE_POLY3_OUT:
                                 if (note_buffer[m_ch].size() > 2)
                                     outputs[ch] = MIDIQuantizer::CV(GetNote(note_buffer[m_ch], 3));
-                                else
+                                else {
                                     if (note_buffer[m_ch].size() == 2) // distribute notes evenly when only 2 are played
                                         outputs[ch] = MIDIQuantizer::CV(GetNoteLast(note_buffer[m_ch]));
                                     else
                                         outputs[ch] = MIDIQuantizer::CV(GetNoteFirst(note_buffer[m_ch]));
+                                }
                                 break;
 
                             case HEM_MIDI_NOTE_POLY4_OUT:
@@ -348,10 +376,12 @@ typedef struct IOFrame {
                         if (note_buffer[m_ch].size() > 0) { // don't update output when last note is released
                             switch(function[ch]) { // note # output functions
                                 case HEM_MIDI_NOTE_OUT:
+                                    if (CheckSustainLatch(m_ch)) break;
                                     outputs[ch] = MIDIQuantizer::CV(GetNoteLast(note_buffer[m_ch]));
                                     break;
 
                                 case HEM_MIDI_NOTE_POLY2_OUT:
+                                    if (CheckSustainLatch(m_ch)) break;
                                     if (note_buffer[m_ch].size() < 2)
                                         outputs[ch] = MIDIQuantizer::CV(GetNoteLast(note_buffer[m_ch]));
                                     else
@@ -359,17 +389,18 @@ typedef struct IOFrame {
                                     break;
 
                                 case HEM_MIDI_NOTE_POLY3_OUT:
+                                    if (CheckSustainLatch(m_ch)) break;
                                     if (note_buffer[m_ch].size() < 3) {
                                         if (note_buffer[m_ch].size() == 2) // distribute notes evenly when only 2 are played
                                             outputs[ch] = MIDIQuantizer::CV(GetNoteLast(note_buffer[m_ch]));
                                         else
                                             outputs[ch] = MIDIQuantizer::CV(GetNoteFirst(note_buffer[m_ch]));
-                                    } else {
+                                    } else
                                         outputs[ch] = MIDIQuantizer::CV(GetNote(note_buffer[m_ch], 3));
-                                    }
                                     break;
 
                                 case HEM_MIDI_NOTE_POLY4_OUT:
+                                    if (CheckSustainLatch(m_ch)) break;
                                     if (note_buffer[m_ch].size() < 4)
                                         outputs[ch] = MIDIQuantizer::CV(GetNoteFirst(note_buffer[m_ch]));
                                     else
@@ -377,34 +408,37 @@ typedef struct IOFrame {
                                     break;
 
                                 case HEM_MIDI_NOTE_MIN_OUT:
+                                    if (CheckSustainLatch(m_ch)) break;
                                     outputs[ch] = MIDIQuantizer::CV(GetNoteMin(note_buffer[m_ch]));
                                     break;
 
                                 case HEM_MIDI_NOTE_MAX_OUT:
+                                    if (CheckSustainLatch(m_ch)) break;
                                     outputs[ch] = MIDIQuantizer::CV(GetNoteMax(note_buffer[m_ch]));
                                     break;
 
                                 case HEM_MIDI_NOTE_PEDAL_OUT:
+                                    if (CheckSustainLatch(m_ch)) break;
                                     outputs[ch] = MIDIQuantizer::CV(GetNoteFirst(note_buffer[m_ch]));
                                     break;
 
                                 case HEM_MIDI_NOTE_INV_OUT:
+                                    if (CheckSustainLatch(m_ch)) break;
                                     outputs[ch] = MIDIQuantizer::CV(GetNoteLastInv(note_buffer[m_ch]));
                                     break;
                             }
                         }
 
-                        // turn gate off only when all notes are off
-                        if (!(note_buffer[m_ch].size() > 0)) {
+                        if (function[ch] == HEM_MIDI_TRIG_ALWAYS_OUT) trigout_q[ch] = 1;
+
+                        // turn gate off only when all notes are off, and sustain pedal up
+                        if (!(note_buffer[m_ch].size() > 0) && !CheckSustainLatch(m_ch)) {
                             if (function[ch] == HEM_MIDI_GATE_OUT) {
                                 outputs[ch] = 0;
                             }
                             if (function[ch] == HEM_MIDI_GATE_INV_OUT) {
                                 outputs[ch] = PULSE_VOLTAGE * (12 << 7);
                             }
-                        } else {
-                            if (function[ch] == HEM_MIDI_TRIG_ALWAYS_OUT)
-                                trigout_q[ch] = 1;
                         }
 
                         switch (function[ch]) {
@@ -426,6 +460,23 @@ typedef struct IOFrame {
                         break;
 
                     case usbMIDI.ControlChange: // Modulation wheel or other CC
+                        // handle sustain pedal
+                        if (data1 == 64) {
+                            if (data2 > 63) {
+                                if (!CheckSustainLatch(m_ch)) SetSustainLatch(m_ch);
+                            } else {
+                                ClearSustainLatch(m_ch);
+                                if (!(note_buffer[m_ch].size() > 0)) {
+                                    if (function[ch] == HEM_MIDI_GATE_OUT) {
+                                        outputs[ch] = 0;
+                                    }
+                                    if (function[ch] == HEM_MIDI_GATE_INV_OUT) {
+                                        outputs[ch] = PULSE_VOLTAGE * (12 << 7);
+                                    }
+                                }
+                            }
+                        }
+
                         if (function[ch] == HEM_MIDI_CC_OUT) {
                             if (function_cc[ch] < 0) function_cc[ch] = data1;
 

--- a/software/src/HSMIDI.h
+++ b/software/src/HSMIDI.h
@@ -87,14 +87,21 @@ enum MIDIFunctions {
     HEM_MIDI_CLOCK_OUT,
     HEM_MIDI_RUN_OUT,
     HEM_MIDI_START_OUT,
-    HEM_MIDI_POLY1_OUT,
-    HEM_MIDI_POLY2_OUT,
-    HEM_MIDI_POLY3_OUT,
-    HEM_MIDI_POLY4_OUT,
+    HEM_MIDI_NOTE_POLY1_OUT,
+    HEM_MIDI_NOTE_POLY2_OUT,
+    HEM_MIDI_NOTE_POLY3_OUT,
+    HEM_MIDI_NOTE_POLY4_OUT,
+    HEM_MIDI_NOTE_MIN_OUT,
+    HEM_MIDI_NOTE_MAX_OUT,
+    HEM_MIDI_NOTE_PEDAL_OUT,
+    HEM_MIDI_NOTE_INV_OUT,
+    HEM_MIDI_TRIG_1ST_OUT,
+    HEM_MIDI_TRIG_ALWAYS_OUT,
+    HEM_MIDI_GATE_INV_OUT,
 
-    HEM_MIDI_MAX_FUNCTION = HEM_MIDI_POLY4_OUT
+    HEM_MIDI_MAX_FUNCTION = HEM_MIDI_GATE_INV_OUT
 };
-const char* const midi_fn_name[HEM_MIDI_MAX_FUNCTION + 1] = {"None", "Note#", "Trig", "Gate", "Veloc", "CC#", "Aft", "Bend", "Clock", "Run", "Start", "Poly1", "Poly2", "Poly3", "Poly4"};
+const char* const midi_fn_name[HEM_MIDI_MAX_FUNCTION + 1] = {"None", "Note#", "Trig", "Gate", "Veloc", "CC#", "Aft", "Bend", "Clock", "Run", "Start", "Poly1", "Poly2", "Poly3", "Poly4", "LoNote", "HiNote", "PdlNote", "InvNote", "Trig1st", "TrgAlws", "GateInv"};
 
 
 /* Hemisphere Suite Data Packing

--- a/software/src/HSMIDI.h
+++ b/software/src/HSMIDI.h
@@ -87,10 +87,14 @@ enum MIDIFunctions {
     HEM_MIDI_CLOCK_OUT,
     HEM_MIDI_RUN_OUT,
     HEM_MIDI_START_OUT,
+    HEM_MIDI_POLY1_OUT,
+    HEM_MIDI_POLY2_OUT,
+    HEM_MIDI_POLY3_OUT,
+    HEM_MIDI_POLY4_OUT,
 
-    HEM_MIDI_MAX_FUNCTION = HEM_MIDI_START_OUT
+    HEM_MIDI_MAX_FUNCTION = HEM_MIDI_POLY4_OUT
 };
-const char* const midi_fn_name[HEM_MIDI_MAX_FUNCTION + 1] = {"None", "Note#", "Trig", "Gate", "Veloc", "CC#", "Aft", "Bend", "Clock", "Run", "Start"};
+const char* const midi_fn_name[HEM_MIDI_MAX_FUNCTION + 1] = {"None", "Note#", "Trig", "Gate", "Veloc", "CC#", "Aft", "Bend", "Clock", "Run", "Start", "Poly1", "Poly2", "Poly3", "Poly4"};
 
 
 /* Hemisphere Suite Data Packing

--- a/software/src/HSMIDI.h
+++ b/software/src/HSMIDI.h
@@ -78,16 +78,6 @@ const char* const midi_channels[17] = {
 enum MIDIFunctions {
     HEM_MIDI_NOOP = 0,
     HEM_MIDI_NOTE_OUT,
-    HEM_MIDI_TRIG_OUT,
-    HEM_MIDI_GATE_OUT,
-    HEM_MIDI_VEL_OUT,
-    HEM_MIDI_CC_OUT,
-    HEM_MIDI_AT_OUT,
-    HEM_MIDI_PB_OUT,
-    HEM_MIDI_CLOCK_OUT,
-    HEM_MIDI_RUN_OUT,
-    HEM_MIDI_START_OUT,
-    HEM_MIDI_NOTE_POLY1_OUT,
     HEM_MIDI_NOTE_POLY2_OUT,
     HEM_MIDI_NOTE_POLY3_OUT,
     HEM_MIDI_NOTE_POLY4_OUT,
@@ -95,13 +85,25 @@ enum MIDIFunctions {
     HEM_MIDI_NOTE_MAX_OUT,
     HEM_MIDI_NOTE_PEDAL_OUT,
     HEM_MIDI_NOTE_INV_OUT,
+    HEM_MIDI_TRIG_OUT,
     HEM_MIDI_TRIG_1ST_OUT,
     HEM_MIDI_TRIG_ALWAYS_OUT,
+    HEM_MIDI_GATE_OUT,
     HEM_MIDI_GATE_INV_OUT,
+    HEM_MIDI_VEL_OUT,
+    HEM_MIDI_VEL2_OUT,
+    HEM_MIDI_VEL3_OUT,
+    HEM_MIDI_VEL4_OUT,
+    HEM_MIDI_CC_OUT,
+    HEM_MIDI_AT_OUT,
+    HEM_MIDI_PB_OUT,
+    HEM_MIDI_CLOCK_OUT,
+    HEM_MIDI_RUN_OUT,
+    HEM_MIDI_START_OUT,
 
-    HEM_MIDI_MAX_FUNCTION = HEM_MIDI_GATE_INV_OUT
+    HEM_MIDI_MAX_FUNCTION = HEM_MIDI_START_OUT
 };
-const char* const midi_fn_name[HEM_MIDI_MAX_FUNCTION + 1] = {"None", "Note#", "Trig", "Gate", "Veloc", "CC#", "Aft", "Bend", "Clock", "Run", "Start", "Poly1", "Poly2", "Poly3", "Poly4", "LoNote", "HiNote", "PdlNote", "InvNote", "Trig1st", "TrgAlws", "GateInv"};
+const char* const midi_fn_name[HEM_MIDI_MAX_FUNCTION + 1] = {"None", "Note1", "Note2", "Note3", "Note4", "LoNote", "HiNote", "PdlNote", "InvNote", "Trig", "Trig1st", "TrgAlws", "Gate", "GateInv", "Veloc1", "Veloc2", "Veloc3", "Veloc4", "CC#", "Aft", "Bend", "Clock", "Run", "Start"};
 
 
 /* Hemisphere Suite Data Packing

--- a/software/src/HSMIDI.h
+++ b/software/src/HSMIDI.h
@@ -45,7 +45,8 @@ extern midi::MidiInterface<midi::SerialMIDI<HardwareSerial> > MIDI1;
 #define HEM_MIDI_NOTE_ON usbMIDI.NoteOn
 #define HEM_MIDI_NOTE_OFF usbMIDI.NoteOff
 #define HEM_MIDI_CC usbMIDI.ControlChange
-#define HEM_MIDI_AFTERTOUCH usbMIDI.AfterTouchChannel
+#define HEM_MIDI_AFTERTOUCH_CHANNEL usbMIDI.AfterTouchChannel
+#define HEM_MIDI_AFTERTOUCH_POLY usbMIDI.AfterTouchPoly
 #define HEM_MIDI_PITCHBEND usbMIDI.PitchBend
 #define HEM_MIDI_SYSEX usbMIDI.SystemExclusive
 
@@ -95,7 +96,11 @@ enum MIDIFunctions {
     HEM_MIDI_VEL3_OUT,
     HEM_MIDI_VEL4_OUT,
     HEM_MIDI_CC_OUT,
-    HEM_MIDI_AT_OUT,
+    HEM_MIDI_AT_CHAN_OUT,
+    HEM_MIDI_AT_KEY1_OUT,
+    HEM_MIDI_AT_KEY2_OUT,
+    HEM_MIDI_AT_KEY3_OUT,
+    HEM_MIDI_AT_KEY4_OUT,
     HEM_MIDI_PB_OUT,
     HEM_MIDI_CLOCK_OUT,
     HEM_MIDI_RUN_OUT,
@@ -103,7 +108,7 @@ enum MIDIFunctions {
 
     HEM_MIDI_MAX_FUNCTION = HEM_MIDI_START_OUT
 };
-const char* const midi_fn_name[HEM_MIDI_MAX_FUNCTION + 1] = {"None", "Note1", "Note2", "Note3", "Note4", "LoNote", "HiNote", "PdlNote", "InvNote", "Trig", "Trig1st", "TrgAlws", "Gate", "GateInv", "Veloc1", "Veloc2", "Veloc3", "Veloc4", "CC#", "Aft", "Bend", "Clock", "Run", "Start"};
+const char* const midi_fn_name[HEM_MIDI_MAX_FUNCTION + 1] = {"None", "Note1", "Note2", "Note3", "Note4", "LoNote", "HiNote", "PdlNote", "InvNote", "Trig", "Trig1st", "TrgAlws", "Gate", "GateInv", "Veloc1", "Veloc2", "Veloc3", "Veloc4", "CC#", "ChanAft", "KeyAft1", "KeyAft2", "KeyAft3", "KeyAft4", "Bend", "Clock", "Run", "Start"};
 
 
 /* Hemisphere Suite Data Packing

--- a/software/src/applets/hMIDIIn.h
+++ b/software/src/applets/hMIDIIn.h
@@ -157,13 +157,22 @@ protected:
 private:
     // Housekeeping
     int cursor; // 0=MIDI channel, 1=A/C function, 2=B/D function
+    int last_icon_ticks[2];
 
     void DrawMonitor() {
-        if (OC::CORE::ticks - frame.MIDIState.last_msg_tick < 4000) {
-            if (hemisphere & 1)
-                gfxBitmap( 9, 1, 8, MIDI_ICON);
-            else
-                gfxBitmap(46, 1, 8, MIDI_ICON);
+        if (cursor != LOG_VIEW) {
+            if ((OC::CORE::ticks - frame.MIDIState.last_msg_tick) < 100) {
+                // reset icon display timers
+                if (frame.MIDIState.channel[io_offset + 0] == frame.MIDIState.last_midi_channel)
+                    last_icon_ticks[0] = OC::CORE::ticks;
+                if (frame.MIDIState.channel[io_offset + 1] == frame.MIDIState.last_midi_channel)
+                    last_icon_ticks[1] = OC::CORE::ticks;
+            }
+
+            if (OC::CORE::ticks - last_icon_ticks[0] < 4000) // ChA midi activity
+                gfxBitmap( 54, 15, 8, MIDI_ICON);
+            if (OC::CORE::ticks - last_icon_ticks[1] < 4000) // ChB midi activity
+                gfxBitmap( 54, 25, 8, MIDI_ICON);
         }
     }
 

--- a/software/src/applets/hMIDIIn.h
+++ b/software/src/applets/hMIDIIn.h
@@ -113,24 +113,30 @@ public:
     }
 
     uint64_t OnDataRequest() {
-        uint64_t data = 0;
-        Pack(data, PackLocation {0,4}, frame.MIDIState.channel[io_offset + 0]);
-        Pack(data, PackLocation {4,4}, frame.MIDIState.channel[io_offset + 1]);
-        Pack(data, PackLocation {8,3}, frame.MIDIState.function[io_offset + 0]);
-        Pack(data, PackLocation {11,3}, frame.MIDIState.function[io_offset + 1]);
-        Pack(data, PackLocation {14,7}, frame.MIDIState.function_cc[io_offset + 0] + 1);
-        Pack(data, PackLocation {21,7}, frame.MIDIState.function_cc[io_offset + 1] + 1);
-        return data;
-    }
+         uint64_t data = 0;
+         Pack(data, PackLocation {0,4}, frame.MIDIState.channel[io_offset + 0]);
+         Pack(data, PackLocation {4,4}, frame.MIDIState.channel[io_offset + 1]);
+         Pack(data, PackLocation {8,3}, frame.MIDIState.function[io_offset + 0]);
+         Pack(data, PackLocation {11,3}, frame.MIDIState.function[io_offset + 1]);
+         // 6 bits empty here
+         Pack(data, PackLocation {14,7}, frame.MIDIState.function_cc[io_offset + 0] + 1);
+         Pack(data, PackLocation {21,7}, frame.MIDIState.function_cc[io_offset + 1] + 1);
 
-    void OnDataReceive(uint64_t data) {
-        frame.MIDIState.channel[io_offset + 0] = Unpack(data, PackLocation {0,4});
-        frame.MIDIState.channel[io_offset + 1] = Unpack(data, PackLocation {4,4});
-        frame.MIDIState.function[io_offset + 0] = Unpack(data, PackLocation {8,3});
-        frame.MIDIState.function[io_offset + 1] = Unpack(data, PackLocation {11,3});
-        frame.MIDIState.function_cc[io_offset + 0] = Unpack(data, PackLocation {14,7}) - 1;
-        frame.MIDIState.function_cc[io_offset + 1] = Unpack(data, PackLocation {21,7}) - 1;
-    }
+         Pack(data, PackLocation {28,5}, frame.MIDIState.function[io_offset + 0]);
+         Pack(data, PackLocation {33,5}, frame.MIDIState.function[io_offset + 1]);
+         return data;
+     }
+
+     void OnDataReceive(uint64_t data) {
+         frame.MIDIState.channel[io_offset + 0] = Unpack(data, PackLocation {0,4});
+         frame.MIDIState.channel[io_offset + 1] = Unpack(data, PackLocation {4,4});
+         frame.MIDIState.function[io_offset + 0] = Unpack(data, PackLocation {8,3});
+         frame.MIDIState.function[io_offset + 1] = Unpack(data, PackLocation {11,3});
+         frame.MIDIState.function[io_offset + 0] = Unpack(data, PackLocation {28,5});
+         frame.MIDIState.function[io_offset + 1] = Unpack(data, PackLocation {33,5});
+         frame.MIDIState.function_cc[io_offset + 0] = Unpack(data, PackLocation {14,7}) - 1;
+         frame.MIDIState.function_cc[io_offset + 1] = Unpack(data, PackLocation {21,7}) - 1;
+     }
 
 protected:
   void SetHelp() {

--- a/software/src/applets/hMIDIIn.h
+++ b/software/src/applets/hMIDIIn.h
@@ -67,6 +67,8 @@ public:
             case HEM_MIDI_CLOCK_OUT:
             case HEM_MIDI_START_OUT:
             case HEM_MIDI_TRIG_OUT:
+            case HEM_MIDI_TRIG_1ST_OUT:
+            case HEM_MIDI_TRIG_ALWAYS_OUT:
                 if (frame.MIDIState.trigout_q[ch_]) {
                     frame.MIDIState.trigout_q[ch_] = 0;
                     ClockOut(ch);
@@ -113,29 +115,29 @@ public:
     }
 
     uint64_t OnDataRequest() {
-         uint64_t data = 0;
-         Pack(data, PackLocation {0,4}, frame.MIDIState.channel[io_offset + 0]);
-         Pack(data, PackLocation {4,4}, frame.MIDIState.channel[io_offset + 1]);
-         Pack(data, PackLocation {8,3}, frame.MIDIState.function[io_offset + 0]);
-         Pack(data, PackLocation {11,3}, frame.MIDIState.function[io_offset + 1]);
-         // 6 bits empty here
-         Pack(data, PackLocation {14,7}, frame.MIDIState.function_cc[io_offset + 0] + 1);
-         Pack(data, PackLocation {21,7}, frame.MIDIState.function_cc[io_offset + 1] + 1);
+        uint64_t data = 0;
+        Pack(data, PackLocation {0,4}, frame.MIDIState.channel[io_offset + 0]);
+        Pack(data, PackLocation {4,4}, frame.MIDIState.channel[io_offset + 1]);
+        Pack(data, PackLocation {8,3}, frame.MIDIState.function[io_offset + 0]);
+        Pack(data, PackLocation {11,3}, frame.MIDIState.function[io_offset + 1]);
+        // 6 bits empty here
+        Pack(data, PackLocation {14,7}, frame.MIDIState.function_cc[io_offset + 0] + 1);
+        Pack(data, PackLocation {21,7}, frame.MIDIState.function_cc[io_offset + 1] + 1);
 
-         Pack(data, PackLocation {28,5}, frame.MIDIState.function[io_offset + 0]);
-         Pack(data, PackLocation {33,5}, frame.MIDIState.function[io_offset + 1]);
-         return data;
+        Pack(data, PackLocation {28,5}, frame.MIDIState.function[io_offset + 0]);
+        Pack(data, PackLocation {33,5}, frame.MIDIState.function[io_offset + 1]);
+        return data;
      }
 
      void OnDataReceive(uint64_t data) {
-         frame.MIDIState.channel[io_offset + 0] = Unpack(data, PackLocation {0,4});
-         frame.MIDIState.channel[io_offset + 1] = Unpack(data, PackLocation {4,4});
-         frame.MIDIState.function[io_offset + 0] = Unpack(data, PackLocation {8,3});
-         frame.MIDIState.function[io_offset + 1] = Unpack(data, PackLocation {11,3});
-         frame.MIDIState.function[io_offset + 0] = Unpack(data, PackLocation {28,5});
-         frame.MIDIState.function[io_offset + 1] = Unpack(data, PackLocation {33,5});
-         frame.MIDIState.function_cc[io_offset + 0] = Unpack(data, PackLocation {14,7}) - 1;
-         frame.MIDIState.function_cc[io_offset + 1] = Unpack(data, PackLocation {21,7}) - 1;
+        frame.MIDIState.channel[io_offset + 0] = Unpack(data, PackLocation {0,4});
+        frame.MIDIState.channel[io_offset + 1] = Unpack(data, PackLocation {4,4});
+        frame.MIDIState.function[io_offset + 0] = Unpack(data, PackLocation {8,3});
+        frame.MIDIState.function[io_offset + 1] = Unpack(data, PackLocation {11,3});
+        frame.MIDIState.function[io_offset + 0] = Unpack(data, PackLocation {28,5});
+        frame.MIDIState.function[io_offset + 1] = Unpack(data, PackLocation {33,5});
+        frame.MIDIState.function_cc[io_offset + 0] = Unpack(data, PackLocation {14,7}) - 1;
+        frame.MIDIState.function_cc[io_offset + 1] = Unpack(data, PackLocation {21,7}) - 1;
      }
 
 protected:
@@ -170,27 +172,27 @@ private:
 
         char out_label[] = { 'C', 'h', (char)('A' + io_offset), ':', '\0'  };
         gfxPrint(1, 15, out_label);
-        gfxPrint(24, 15, frame.MIDIState.channel[io_offset + 0] + 1);
+        gfxPrint(27, 15, frame.MIDIState.channel[io_offset + 0] + 1);
         ++out_label[2];
         gfxPrint(1, 25, out_label);
-        gfxPrint(24, 25, frame.MIDIState.channel[io_offset + 1] + 1);
+        gfxPrint(27, 25, frame.MIDIState.channel[io_offset + 1] + 1);
 
         // Output 1 function
-        char out_label_fn[] = { (char)('A' + io_offset), ' ', ':', '\0'  };
+        char out_label_fn[] = { (char)('A' + io_offset), ':', '\0'  };
         gfxPrint(1, 35, out_label_fn);
-        gfxPrint(24, 35, midi_fn_name[frame.MIDIState.function[io_offset + 0]]);
+        gfxPrint(16, 35, midi_fn_name[frame.MIDIState.function[io_offset + 0]]);
         if (frame.MIDIState.function[io_offset + 0] == HEM_MIDI_CC_OUT)
             gfxPrint(frame.MIDIState.function_cc[io_offset + 0]);
 
         // Output 2 function
         ++out_label_fn[0];
         gfxPrint(1, 45, out_label_fn);
-        gfxPrint(24, 45, midi_fn_name[frame.MIDIState.function[io_offset + 1]]);
+        gfxPrint(16, 45, midi_fn_name[frame.MIDIState.function[io_offset + 1]]);
         if (frame.MIDIState.function[io_offset + 1] == HEM_MIDI_CC_OUT)
             gfxPrint(frame.MIDIState.function_cc[io_offset + 1]);
 
         // Cursor
-        gfxCursor(24, 23 + (cursor * 10), 39);
+        gfxCursor(24 - ((cursor > 1) * 12), 23 + (cursor * 10), 39 + ((cursor > 1) * 12));
 
         // Last log entry
         if (frame.MIDIState.log_index > 0) {

--- a/software/src/applets/hMIDIIn.h
+++ b/software/src/applets/hMIDIIn.h
@@ -25,7 +25,6 @@
 
 class hMIDIIn : public HemisphereApplet {
 public:
-
     enum hMIDIInCursor {
         MIDI_CHANNEL_A,
         MIDI_CHANNEL_B,
@@ -42,8 +41,7 @@ public:
     const uint8_t* applet_icon() { return PhzIcons::midiIn; }
 
     void Start() {
-        ForEachChannel(ch)
-        {
+        ForEachChannel(ch) {
             int ch_ = ch + io_offset;
             frame.MIDIState.channel[ch_] = 0; // Default channel 1
             frame.MIDIState.function[ch_] = HEM_MIDI_NOOP;
@@ -85,9 +83,11 @@ public:
     }
 
     void View() {
-        DrawMonitor();
         if (cursor == LOG_VIEW) DrawLog();
-        else DrawSelector();
+        else {
+            DrawMonitor();
+            DrawSelector();
+        }
     }
 
     //void OnButtonPress() { }
@@ -127,9 +127,9 @@ public:
         Pack(data, PackLocation {28,5}, frame.MIDIState.function[io_offset + 0]);
         Pack(data, PackLocation {33,5}, frame.MIDIState.function[io_offset + 1]);
         return data;
-     }
+    }
 
-     void OnDataReceive(uint64_t data) {
+    void OnDataReceive(uint64_t data) {
         frame.MIDIState.channel[io_offset + 0] = Unpack(data, PackLocation {0,4});
         frame.MIDIState.channel[io_offset + 1] = Unpack(data, PackLocation {4,4});
         frame.MIDIState.function[io_offset + 0] = Unpack(data, PackLocation {8,3});
@@ -138,21 +138,21 @@ public:
         frame.MIDIState.function[io_offset + 1] = Unpack(data, PackLocation {33,5});
         frame.MIDIState.function_cc[io_offset + 0] = Unpack(data, PackLocation {14,7}) - 1;
         frame.MIDIState.function_cc[io_offset + 1] = Unpack(data, PackLocation {21,7}) - 1;
-     }
+    }
 
 protected:
-  void SetHelp() {
-    //                    "-------" <-- Label size guide
-    //help[HELP_DIGITAL1] = "";
-    //help[HELP_DIGITAL2] = "";
-    //help[HELP_CV1]      = "";
-    //help[HELP_CV2]      = "";
-    help[HELP_OUT1]     = midi_fn_name[frame.MIDIState.function[io_offset + 0]];
-    help[HELP_OUT2]     = midi_fn_name[frame.MIDIState.function[io_offset + 1]];
-    //help[HELP_EXTRA1]  = "";
-    //help[HELP_EXTRA2]  = "";
-    //                   "---------------------" <-- Extra text size guide
-  }
+    void SetHelp() {
+        //                      "-------" <-- Label size guide
+        //help[HELP_DIGITAL1] = "";
+        //help[HELP_DIGITAL2] = "";
+        //help[HELP_CV1]      = "";
+        //help[HELP_CV2]      = "";
+        help[HELP_OUT1]       = midi_fn_name[frame.MIDIState.function[io_offset + 0]];
+        help[HELP_OUT2]       = midi_fn_name[frame.MIDIState.function[io_offset + 1]];
+        //help[HELP_EXTRA1]   = "";
+        //help[HELP_EXTRA2]   = "";
+        //                      "---------------------" <-- Extra text size guide
+    }
 
 private:
     // Housekeeping
@@ -160,26 +160,24 @@ private:
     int last_icon_ticks[2];
 
     void DrawMonitor() {
-        if (cursor != LOG_VIEW) {
-            if ((OC::CORE::ticks - frame.MIDIState.last_msg_tick) < 100) {
-                // reset icon display timers
-                if (frame.MIDIState.channel[io_offset + 0] == frame.MIDIState.last_midi_channel)
-                    last_icon_ticks[0] = OC::CORE::ticks;
-                if (frame.MIDIState.channel[io_offset + 1] == frame.MIDIState.last_midi_channel)
-                    last_icon_ticks[1] = OC::CORE::ticks;
-            }
-
-            if (OC::CORE::ticks - last_icon_ticks[0] < 4000) // ChA midi activity
-                gfxBitmap( 54, 15, 8, MIDI_ICON);
-            if (OC::CORE::ticks - last_icon_ticks[1] < 4000) // ChB midi activity
-                gfxBitmap( 54, 25, 8, MIDI_ICON);
+        if ((OC::CORE::ticks - frame.MIDIState.last_msg_tick) < 100) {
+            // reset icon display timers
+            if (frame.MIDIState.channel[io_offset + 0] == frame.MIDIState.last_midi_channel)
+                last_icon_ticks[0] = OC::CORE::ticks;
+            if (frame.MIDIState.channel[io_offset + 1] == frame.MIDIState.last_midi_channel)
+                last_icon_ticks[1] = OC::CORE::ticks;
         }
+
+        if (OC::CORE::ticks - last_icon_ticks[0] < 4000) // ChA midi activity
+            gfxBitmap( 54, 15, 8, MIDI_ICON);
+        if (OC::CORE::ticks - last_icon_ticks[1] < 4000) // ChB midi activity
+            gfxBitmap( 54, 25, 8, MIDI_ICON);
     }
 
     void DrawSelector() {
         // MIDI Channels
 
-        char out_label[] = { 'C', 'h', (char)('A' + io_offset), ':', '\0'  };
+        char out_label[] = { 'C', 'h', (char)('A' + io_offset), ':', '\0' };
         gfxPrint(1, 15, out_label);
         gfxPrint(27, 15, frame.MIDIState.channel[io_offset + 0] + 1);
         ++out_label[2];
@@ -187,7 +185,7 @@ private:
         gfxPrint(27, 25, frame.MIDIState.channel[io_offset + 1] + 1);
 
         // Output 1 function
-        char out_label_fn[] = { (char)('A' + io_offset), ':', '\0'  };
+        char out_label_fn[] = { (char)('A' + io_offset), ':', '\0' };
         gfxPrint(1, 35, out_label_fn);
         gfxPrint(16, 35, midi_fn_name[frame.MIDIState.function[io_offset + 0]]);
         if (frame.MIDIState.function[io_offset + 0] == HEM_MIDI_CC_OUT)
@@ -212,8 +210,7 @@ private:
 
     void DrawLog() {
         if (frame.MIDIState.log_index) {
-            for (int i = 0; i < frame.MIDIState.log_index; i++)
-            {
+            for (int i = 0; i < frame.MIDIState.log_index; i++) {
                 PrintLogEntry(15 + (i * 8), i);
             }
         }
@@ -239,9 +236,14 @@ private:
             gfxPrint(10, y, log_entry_.data2);
             break;
 
-        case HEM_MIDI_AFTERTOUCH:
+        case HEM_MIDI_AFTERTOUCH_CHANNEL:
             gfxBitmap(1, y, 8, AFTERTOUCH_ICON);
             gfxPrint(10, y, log_entry_.data1);
+            break;
+
+        case HEM_MIDI_AFTERTOUCH_POLY:
+            gfxBitmap(1, y, 8, AFTERTOUCH_ICON);
+            gfxPrint(10, y, log_entry_.data2);
             break;
 
         case HEM_MIDI_PITCHBEND: {

--- a/software/src/applets/hMIDIIn.h
+++ b/software/src/applets/hMIDIIn.h
@@ -53,6 +53,7 @@ public:
 
         frame.MIDIState.log_index = 0;
         frame.MIDIState.clock_count = 0;
+        frame.MIDIState.NoteStackClear();
     }
 
     void Controller() {
@@ -110,7 +111,7 @@ public:
         }
         ResetCursor();
     }
-        
+
     uint64_t OnDataRequest() {
         uint64_t data = 0;
         Pack(data, PackLocation {0,4}, frame.MIDIState.channel[io_offset + 0]);
@@ -148,7 +149,7 @@ protected:
 private:
     // Housekeeping
     int cursor; // 0=MIDI channel, 1=A/C function, 2=B/D function
-    
+
     void DrawMonitor() {
         if (OC::CORE::ticks - frame.MIDIState.last_msg_tick < 4000) {
             gfxBitmap(46, 1, 8, MIDI_ICON);
@@ -157,7 +158,7 @@ private:
 
     void DrawSelector() {
         // MIDI Channels
-        
+
         char out_label[] = { 'C', 'h', (char)('A' + io_offset), ':', '\0'  };
         gfxPrint(1, 15, out_label);
         gfxPrint(24, 15, frame.MIDIState.channel[io_offset + 0] + 1);

--- a/software/src/applets/hMIDIIn.h
+++ b/software/src/applets/hMIDIIn.h
@@ -152,7 +152,10 @@ private:
 
     void DrawMonitor() {
         if (OC::CORE::ticks - frame.MIDIState.last_msg_tick < 4000) {
-            gfxBitmap(46, 1, 8, MIDI_ICON);
+            if (hemisphere & 1)
+                gfxBitmap( 9, 1, 8, MIDI_ICON);
+            else
+                gfxBitmap(46, 1, 8, MIDI_ICON);
         }
     }
 

--- a/software/src/applets/hMIDIIn.h
+++ b/software/src/applets/hMIDIIn.h
@@ -51,7 +51,7 @@ public:
 
         frame.MIDIState.log_index = 0;
         frame.MIDIState.clock_count = 0;
-        frame.MIDIState.NoteStackClear();
+        frame.MIDIState.ClearNoteStack();
     }
 
     void Controller() {

--- a/software/src/applets/hMIDIOut.h
+++ b/software/src/applets/hMIDIOut.h
@@ -23,18 +23,18 @@
 // The functions available for each output
 class hMIDIOut : public HemisphereApplet {
 public:
-  enum MIDIOutCursor {
-    CHANNEL, TRANSPOSE, CV2_FUNC, LEGATO,
-    LOG_VIEW,
+    enum MIDIOutCursor {
+        CHANNEL, TRANSPOSE, CV2_FUNC, LEGATO,
+        LOG_VIEW,
 
-    MAX_CURSOR = LOG_VIEW
-  };
-  enum MIDIOutMode {
-    HEM_MIDI_CC_IN,
-    HEM_MIDI_AT_IN,
-    HEM_MIDI_PB_IN,
-    HEM_MIDI_VEL_IN,
-  };
+        MAX_CURSOR = LOG_VIEW
+    };
+    enum MIDIOutMode {
+        HEM_MIDI_CC_IN,
+        HEM_MIDI_AT_IN,
+        HEM_MIDI_PB_IN,
+        HEM_MIDI_VEL_IN,
+    };
 
     const char* applet_name() { // Maximum 10 characters
         return "MIDIOut";
@@ -110,10 +110,10 @@ public:
                 if (function == HEM_MIDI_CC_IN) {
                     int value = ProportionCV(In(1), 127);
                     if (value != last_cc) {
-                      hMIDI.SendCC(channel, 1, value);
-                      last_cc = value;
-                      UpdateLog(HEM_MIDI_CC, value, 0);
-                      last_tick = OC::CORE::ticks;
+                        hMIDI.SendCC(channel, 1, value);
+                        last_cc = value;
+                        UpdateLog(HEM_MIDI_CC, value, 0);
+                        last_tick = OC::CORE::ticks;
                     }
                 }
 
@@ -121,10 +121,10 @@ public:
                 if (function == HEM_MIDI_AT_IN) {
                     int value = ProportionCV(In(1), 127);
                     if (value != last_at) {
-                      hMIDI.SendAfterTouch(channel, value);
-                      last_at = value;
-                      UpdateLog(HEM_MIDI_AFTERTOUCH, value, 0);
-                      last_tick = OC::CORE::ticks;
+                        hMIDI.SendAfterTouch(channel, value);
+                        last_at = value;
+                        UpdateLog(HEM_MIDI_AFTERTOUCH_CHANNEL, value, 0);
+                        last_tick = OC::CORE::ticks;
                     }
                 }
 
@@ -133,10 +133,10 @@ public:
                     uint16_t bend = Proportion(In(1) + HEMISPHERE_3V_CV, HEMISPHERE_3V_CV * 2, 16383);
                     bend = constrain(bend, 0, 16383);
                     if (bend != last_bend) {
-                      hMIDI.SendPitchBend(channel, bend);
-                      last_bend = bend;
-                      UpdateLog(HEM_MIDI_PITCHBEND, bend - 8192, 0);
-                      last_tick = OC::CORE::ticks;
+                        hMIDI.SendPitchBend(channel, bend);
+                        last_bend = bend;
+                        UpdateLog(HEM_MIDI_PITCHBEND, bend - 8192, 0);
+                        last_tick = OC::CORE::ticks;
                     }
                 }
             }
@@ -166,22 +166,27 @@ public:
         }
 
         switch (cursor) {
-        case CHANNEL:
-          channel = constrain(channel + direction, 0, 15);
-          HS::frame.MIDIState.outchan[io_offset + 0] = channel;
-          HS::frame.MIDIState.outchan[io_offset + 1] = channel;
-          break;
-        case TRANSPOSE: transpose = constrain(transpose + direction, -24, 24);
+            case CHANNEL:
+                channel = constrain(channel + direction, 0, 15);
+                HS::frame.MIDIState.outchan[io_offset + 0] = channel;
+                HS::frame.MIDIState.outchan[io_offset + 1] = channel;
                 break;
-        case CV2_FUNC:
-          function = constrain(function + direction, 0, 3);
-          HS::frame.MIDIState.outfn[io_offset + 0] = HEM_MIDI_NOTE_OUT;
-          if (function == HEM_MIDI_CC_IN)
-            HS::frame.MIDIState.outfn[io_offset + 1] = HEM_MIDI_CC_OUT;
-          else
-            HS::frame.MIDIState.outfn[io_offset + 1] = HEM_MIDI_GATE_OUT;
-          break;
-        case LEGATO: legato = direction > 0 ? 1 : 0;
+
+            case TRANSPOSE:
+                transpose = constrain(transpose + direction, -24, 24);
+                break;
+
+            case CV2_FUNC:
+                function = constrain(function + direction, 0, 3);
+                HS::frame.MIDIState.outfn[io_offset + 0] = HEM_MIDI_NOTE_OUT;
+                if (function == HEM_MIDI_CC_IN)
+                    HS::frame.MIDIState.outfn[io_offset + 1] = HEM_MIDI_CC_OUT;
+                else
+                    HS::frame.MIDIState.outfn[io_offset + 1] = HEM_MIDI_GATE_OUT;
+                break;
+
+            case LEGATO:
+                legato = direction > 0 ? 1 : 0;
                 break;
         }
         ResetCursor();
@@ -202,18 +207,18 @@ public:
     }
 
 protected:
-  void SetHelp() {
-    //                    "-------" <-- Label size guide
-    help[HELP_DIGITAL1] = "Gate";
-    help[HELP_DIGITAL2] = "";
-    help[HELP_CV1]      = "Pitch";
-    help[HELP_CV2]      = fn_name[function];
-    help[HELP_OUT1]     = "";
-    help[HELP_OUT2]     = "";
-    help[HELP_EXTRA1]  = "";
-    help[HELP_EXTRA2]  = "";
-    //                   "---------------------" <-- Extra text size guide
-  }
+    void SetHelp() {
+        //                    "-------" <-- Label size guide
+        help[HELP_DIGITAL1] = "Gate";
+        help[HELP_DIGITAL2] = "";
+        help[HELP_CV1]      = "Pitch";
+        help[HELP_CV2]      = fn_name[function];
+        help[HELP_OUT1]     = "";
+        help[HELP_OUT2]     = "";
+        help[HELP_EXTRA1]   = "";
+        help[HELP_EXTRA2]   = "";
+        //                    "---------------------" <-- Extra text size guide
+    }
 
 private:
     // Settings
@@ -243,8 +248,7 @@ private:
     void UpdateLog(int message, int data1, int data2) {
         log[log_index++] = {message, data1, data2};
         if (log_index == 7) {
-            for (int i = 0; i < 6; i++)
-            {
+            for (int i = 0; i < 6; i++) {
                 memcpy(&log[i], &log[i+1], sizeof(log[i+1]));
             }
             log_index--;
@@ -292,8 +296,7 @@ private:
 
     void DrawLog() {
         if (log_index) {
-            for (int i = 0; i < log_index; i++)
-            {
+            for (int i = 0; i < log_index; i++) {
                 log_entry(15 + (i * 8), i);
             }
         }
@@ -316,7 +319,7 @@ private:
             gfxPrint(10, y, log[index].data1);
         }
 
-        if (log[index].message == HEM_MIDI_AFTERTOUCH) {
+        if (log[index].message == HEM_MIDI_AFTERTOUCH_CHANNEL) {
             gfxBitmap(1, y, 8, AFTERTOUCH_ICON);
             gfxPrint(10, y, log[index].data1);
         }

--- a/software/src/applets/hMIDIOut.h
+++ b/software/src/applets/hMIDIOut.h
@@ -186,7 +186,7 @@ public:
         }
         ResetCursor();
     }
-        
+
     uint64_t OnDataRequest() {
         uint64_t data = 0;
         Pack(data, PackLocation {0,4}, channel);
@@ -253,7 +253,10 @@ private:
 
     void DrawMonitor() {
         if (OC::CORE::ticks - last_tick < 4000) {
-            gfxBitmap(46, 1, 8, MIDI_ICON);
+            if (hemisphere & 1)
+                gfxBitmap( 9, 1, 8, MIDI_ICON);
+            else
+                gfxBitmap(46, 1, 8, MIDI_ICON);
         }
     }
 


### PR DESCRIPTION
MIDI note and velocity input is now buffered to facilitate legato playing, and polyphony.
Notes are remembered in the order played, limited only by free memory.

Fixes #32 

The following new output modes are added:

Note1, Note2, Note3, Note4:
    V/Oct CV from the 4 most recent notes can be sent to individual outputs.
    When less than 4 notes are played, notes are distributed somewhat evenly.
    Eg., when only 2 notes are held, outputs 1 and 3 play the newer note, outputs 2 and 4 play the older note.

LoNote, HiNote:
    V/Oct corresponding to the lowest and highest held note, pretty simple.

PdlNote:
    V/Oct corresponding to the ["pedal" note](https://en.wikipedia.org/wiki/Pedal_point), or the earliest played note. If this note is released, the next earliest is played.
    Useful as a drone over which other notes can be performed from a 2nd output.

InvNote:
    V/Oct output corresponding to an "inverted" keyboard. High keys play low notes, and low keys play high notes. 
    (127 - MidiNote)

Trig1st:
    Same as Trig, but only triggers on the 1st played note. Useful for interesting 1-shot effects.

TrgAlws:
    Same as Trig, but also triggers when notes are released.

GateInv:
    Same as Gate, but high with no notes held, and low when notes are held.
    Tip: Try setting 2 outputs as Gate and GateInv respectively, then trigger 2 different voices in stereo.

Veloc1, Veloc2, Veloc3, Veloc4:
    Outputs the velocity from the last 4 played notes. 


Applet UI has been updated to allow more characters, and to fix the overlap issue with the right hemisphere activity monitor icon in MIDIOut. MIDIIn now monitors MIDI activity per ADC channel.
Logging has been updated to prevent duplicate note entries on the same MIDI channel.


I think some of the stuff at the bottom of HSIOFrame.h is showing changed because of the whitespace differences.
