### PR TITLE
Add Hold Pitch feature to TB-3PO

### DIFF
--- a/docs/_applets/TB-3PO.md
+++ b/docs/_applets/TB-3PO.md
@@ -26,6 +26,7 @@ layout: default
 * Quantizer select
   - AuxButton for popup editor
 * Pattern Length
+* Hold pitch
 
 ## Seed
 The seed parameter controls the random pattern generation. This is done deterministically, which means for the same seed you'll get the same patterns, based on the other controls.
@@ -72,6 +73,11 @@ While this parameter is highlighted for editing, press the AuxButton (select but
 ## Pattern Length
 Sets the length of the pattern from 1-32 steps. This doesn't alter the pattern apart from setting the loop point.
 
+## Hold pitch
+When enabled, the pitch CV is held at the last gated step's pitch when steps are not gated. When a step is gated, the pitch updates to that step's pitch. When disabled, the pitch updates on every step (or glides when slides are active).
+
+Toggle hold pitch mode by turning the encoder or pressing the AuxButton (select button) when the parameter is selected.
+
 ## Step Settings
 Like on the TB-303, each step can have Gate, Accent, Glide, +octave or -octave set on it. TB-3PO chooses these values randomly based on the seed and some 303-like rules. Gates emulate the TB-303 by going high for 50% of the detected clock rate, unless they have slide set. In this case they stay high through the next step, when an exponential, fixed-time glide to the next step's pitch is engaged. Accent steps output the gate at 5v instead of 3v, which may be useful with a secondary VCA to punch them a bit.
 
@@ -86,6 +92,8 @@ Like on the TB-303, each step can have Gate, Accent, Glide, +octave or -octave s
   - A note-with-arrow icon indicates a step that has Slide active
   - A wiggly waveform icon shows that an active exponential pitch bend is occurring to reach the current step's pitch
   - UP and DOWN arrows indicate if the current step is transposed up or down by one octave, respectively
+  - "-" Indicates that hold pitch mode is active and the current step is not gated, so the pitch is being held from the previous gated step
+- An "H" indicator shows hold pitch mode. When hold pitch is active, the "H" is framed 
 
 ## Credits
 Authored by Logarhythm1, with various modifications by djphazer

--- a/software/src/applets/TB3PO.h
+++ b/software/src/applets/TB3PO.h
@@ -41,9 +41,9 @@ class TB_3PO: public HemisphereApplet {
 
     enum TB3POCursor {
       LOCK_SEED, DIGIT1, DIGIT2, DIGIT3, DIGIT4,
-      DENSITY, QSELECT, TRANS_MODE, LENGTH,
+      DENSITY, QSELECT, TRANS_MODE, LENGTH, HOLD_PITCH,
 
-      MAX_CURSOR = LENGTH
+      MAX_CURSOR = HOLD_PITCH
     };
 
     const char * applet_name() { // Maximum 10 characters
@@ -120,7 +120,8 @@ class TB_3PO: public HemisphereApplet {
         slide_start_cv = curr_pitch_cv;
 
         slide_end_cv = get_pitch_for_step(step);
-      } else {
+      } else if (!hold_pitch || step_is_gated(step)) {
+        // No glide but new pitch
         curr_pitch_cv = get_pitch_for_step(step);
         slide_start_cv = curr_pitch_cv;
         slide_end_cv = curr_pitch_cv;
@@ -196,6 +197,9 @@ class TB_3PO: public HemisphereApplet {
     if (cursor == LENGTH) {
       no_slides ^= 1;
     }
+    if (cursor == HOLD_PITCH) {
+      hold_pitch ^= 1;
+    }
     CancelEdit();
   }
 
@@ -249,6 +253,9 @@ class TB_3PO: public HemisphereApplet {
     case LENGTH: // pattern length
       num_steps = constrain(num_steps + direction, 1, 32);
       break;
+    case HOLD_PITCH:
+      hold_pitch ^= 1;
+      break;
     } //switch
   } //OnEncoderMove
 
@@ -270,6 +277,8 @@ class TB_3PO: public HemisphereApplet {
 
     Pack(data, PackLocation { 48, 4 }, qselect);
 
+    Pack(data, PackLocation { 52, 1 }, hold_pitch);
+
     return data;
   }
 
@@ -285,6 +294,8 @@ class TB_3PO: public HemisphereApplet {
     CONSTRAIN(qselect, 0, QUANT_CHANNEL_COUNT - 1);
 
     set_quantizer_scale();
+
+    hold_pitch = Unpack(data, PackLocation { 52, 1 });
 
     CONSTRAIN(density_encoder, 0, 14); // Internally just positive
     density = density_encoder;
@@ -318,6 +329,7 @@ private:
 
   int lock_seed; // If 1, the seed won't randomize (and manual editing is enabled)
   bool no_slides = false;
+  bool hold_pitch = false;
   bool transpose_in_semitones = false;
 
   uint16_t seed; // The random seed that deterministically builds the sequence
@@ -697,6 +709,10 @@ private:
     gfxPrint(1 + pad(10, display_step), 47, display_step); // Pad x enough to hold width steady
     gfxPrint("/");
     gfxPrint(num_steps);
+    gfxPrint(32, 47, "H"); // Indicate hold pitch mode
+    if (hold_pitch) {
+      gfxFrame(31, 45, 9, 11, true);
+    }
 
     // Show octave icons
     if (step_is_oct_down(step)) {
@@ -738,6 +754,9 @@ private:
     if (no_slides) {
       gfxPrint(42, 46, "X");
     }
+    if (hold_pitch && !step_is_gated(step)) {
+      gfxPrint(42, 46, "-");
+    }
 
     // Show that the "slide circuit" is actively
     // sliding the pitch (one step after the slid step)
@@ -774,6 +793,10 @@ private:
     case LENGTH:
       gfxSpicyCursor(20, 54, 12, 8);
       gfxIcon(33, 47, LEFT_ICON, true);
+      break;
+    case HOLD_PITCH:
+      gfxSpicyCursor(31, 55, 9, 8);
+      gfxIcon(41, 47, LEFT_ICON);
       break;
     }
   }


### PR DESCRIPTION
Adds a hold pitch mode to TB-3PO that holds the pitch CV at the last gated step's pitch when steps are not gated. Previously, this would require an external sample & hold module.

**Behavior:**
When enabled: pitch is held on non-gated steps; updates normally on gated steps
When disabled: pitch updates on every step (or glides when slides are active)

**Controls:**
Toggle via encoder or AuxButton when the Hold pitch parameter is selected
Visual indicator: "H" appears in the display, framed when active
"-" icon shows when pitch is being held on a non-gated step

This allows sustaining pitch across rests in the pattern, useful for creating legato lines and maintaining pitch continuity.