### PR TITLE
Runglbook cvify threshold

### DIFF
--- a/docs/_applets/RunglBook.md
+++ b/docs/_applets/RunglBook.md
@@ -11,9 +11,9 @@ layout: default
 
 |        | 1/3 | 2/4 |
 | ------ | :-: | :-: |
-| TRIG   |  Clock   |  Freeze   |
-| CV INs | Signal    |  N/A   |
-| OUTs   |  Rungle output (low three bits)   | Rungle output (high three bits)    |
+| TRIG   | Clock     |  Freeze   |
+| CV INs | Signal    |  Threshold   |
+| OUTs   | Rungle output (low three bits)   | Rungle output (high three bits)    |
 
 ## UI Parameters
  * Threshold (semitone increments)

--- a/software/src/applets/RunglBook.h
+++ b/software/src/applets/RunglBook.h
@@ -19,6 +19,7 @@
 // SOFTWARE.
 
 // Modified by Samuel Burt 2023
+// Modified by Mace Ojala 2026
 
 class RunglBook : public HemisphereApplet {
 public:
@@ -33,6 +34,8 @@ public:
     }
 
     void Controller() {
+	Modulate(threshold, 1, (12 << 7), (12 << 7) * 5);
+
         if (Clock(0)) {
             if (Gate(1)) {
                 // Digital 2 freezes the buffer, so just rotate left
@@ -78,7 +81,7 @@ protected:
     help[HELP_DIGITAL1] = "Clock";
     help[HELP_DIGITAL2] = "Freeze";
     help[HELP_CV1]      = "Signal";
-    help[HELP_CV2]      = "";
+    help[HELP_CV2]      = "Thr";
     help[HELP_OUT1]     = "Rungle";
     help[HELP_OUT2]     = "Alt";
     help[HELP_EXTRA1] = "Set: Threshold";

--- a/software/src/applets/RunglBook.h
+++ b/software/src/applets/RunglBook.h
@@ -34,7 +34,7 @@ public:
     }
 
     void Controller() {
-	Modulate(threshold, 1, (12 << 7), (12 << 7) * 5);
+        threshold = constrain(In(1), (12 << 7), (12 << 7) * 5);
 
         if (Clock(0)) {
             if (Gate(1)) {


### PR DESCRIPTION
Just an itsybitsy modification I mentioned in the compilation issue, to the RunglBook to expose the _threshold_ to modulation via the second CV. It was unassigned so I figured that could be fun.

Seems to be working based on testing on device. I think...