### PR TITLE
Piqued: flip CV inputs when display is flipped

### DIFF
--- a/software/src/APP_ENVGEN.h
+++ b/software/src/APP_ENVGEN.h
@@ -808,7 +808,13 @@ public:
     cv4.push(OC::ADC::value<ADC_CHANNEL_4>());
 #endif
 
-    const int32_t cvs[ENVGEN_CHANNEL_COUNT] = { cv1.value(), cv2.value(), cv3.value(), cv4.value() };
+    const bool cv_flip = OC::calibration_data.flipcontrols();
+    const int32_t cvs[ENVGEN_CHANNEL_COUNT] = {
+      cv_flip ? cv4.value() : cv1.value(),
+      cv_flip ? cv3.value() : cv2.value(),
+      cv_flip ? cv2.value() : cv3.value(),
+      cv_flip ? cv1.value() : cv4.value()
+    };
     uint32_t triggers = OC::DigitalInputs::clocked();
 
     uint32_t internal_trigger_mask =


### PR DESCRIPTION
I recently started using the Piqued app and noticed that the CV inputs don't change according to the flipcontrol or flipscreen settings while the Trigger in and CV Outputs do. This change fixes that, but I wasn't sure whether to use `flipcontrol()` or `flipscreen()`. This PR was made with the help of Claude Code.

Thanks for this project - it's been invaluable (and fun)!