### PR TITLE
Add Panner applet: CV-controllable panner

### DIFF
--- a/docs/App-and-Applet-Index.md
+++ b/docs/App-and-Applet-Index.md
@@ -95,6 +95,7 @@ Newer ORN8 hardware (T41) hosts the same set of Applets, four at a time, inside 
 * [MarkovPerc](MarkovPerc) - first-order Markov chain rhythmic generator
 * [MultiScale](MultiScale) - like ScaleDuet, but with 4 scale masks
 * [Palimpsest](Palimpsest) - accent sequencer
+* [Panner](Panner) - routes one CV signal between two outputs, with gate-controllable hard pan
 * [Pigeons](Pigeons) - dual Fibonacci-style melody generator
 * [PolyDiv](PolyDiv) - four concurrent clock dividers with assignable outputs
 * [ProbDiv](ProbDiv) - stochastic trigger generator
@@ -181,7 +182,7 @@ _(note: T41 Audio Applets are not included here)_
 | **Envelope Generator**       | [ADSR](ADSR-EG), [AD EG](AD-EG), [Ebb & LFO](Ebb-&-LFO), [EnvSeq](EnvSeq), [VectorEG](VectorEG)  | [Piqued](Piqued), [Dialectic Ping Pong](Dialectic-Ping-Pong) |
 | **LFO**                      | [Ebb & LFO](Ebb-&-LFO), [LowerRenz](LowerRenz), [Relabi](Relabi), [VectorLFO](VectorLFO)   | [Quadraturia](Quadraturia) |
 | **MIDI**                     | [MIDI In](MIDI-Input), [MIDI Out](MIDI-Out) _(See also: [MIDI Maps](MIDI-Maps), [Auto MIDI Output](Hemisphere-General-Settings#auto-midi-output))_   | [Captain MIDI](Captain-MIDI) |
-| **Mixer**                    | [AttenOff](AttenOff), [Calculate](Calculate), [Combin8](Combin8), [Squanch](Squanch), [Xfader](Xfader) |    |
+| **Mixer**                    | [AttenOff](AttenOff), [Calculate](Calculate), [Combin8](Combin8), [Panner](Panner), [Squanch](Squanch), [Xfader](Xfader) |    |
 | **Modulation Source**        | [GameOfLife](GameOfLife), [Relabi](Relabi) [Stairs](Stairs), [VectorMorph](VectorMorph) | [Low-rents](Low-rents), [Pong](Pong) |
 | **Performance Utility**      | [Button2](Button2), [Voltage](Voltage) |  [Scenery](Scenery) |
 | **Pitch Sequencer**          | [Carpeggio](Carpeggio), [TwoRings](TwoRings), [Enigma Jr.](Enigma-Jr), [MarkoV](MarkoV), [Pigeons](Pigeons), [ProbMeloD](ProbMeloD), [Seq32](Seq32), [SeqPlay7](SeqPlay7), [SequenceX](SequenceX), [Shredder](Shredder), [Strum](Strum), [SwitchSeq](Switch-Seq), [TB-3PO](TB-3PO) | [Enigma](Enigma), [The Darkest Timeline](The-Darkest-Timeline), [Automatonnetz](Automatonnetz), [Sequins](Sequins), [Acid Curds](Acid-Curds), [Passencore](Passencore) |

--- a/docs/_applets/Panner.md
+++ b/docs/_applets/Panner.md
@@ -1,0 +1,40 @@
+---
+layout: default
+---
+# Panner
+
+<!-- TODO: add screenshot -> ![Panner Screenshot](images/Panner.png) -->
+
+**Panner** takes a single CV signal and distributes it between two complementary outputs, like the pan control on a mixer channel. It is derived from [Xfader](Xfader), but where Xfader mixes two inputs down, Panner spreads one input out.
+
+### I/O
+
+|        | 1/3        | 2/4         |
+| ------ | :--------: | :---------: |
+| TRIG   | Hard Left  | Hard Right  |
+| CV INs | Signal     | Pan CV      |
+| OUTs   | Left       | Right       |
+
+### UI Control
+* Encoder: Adjusts the pan position
+
+The two level bars show the gain currently applied to the left and right outputs. They are complementary: with the position all the way left, the full signal appears at OUT 1/3 and nothing at OUT 2/4; all the way right is the reverse; at center both outputs get half. Unlike Xfader, the signal is not pre-attenuated, so a centered panner gives each side 50% of the input level.
+
+The bar below the level meters shows the position. The vertical tick marks the base position set by the encoder, and the small caret marks the live position after CV and gates are applied.
+
+### Pan CV
+
+CV 2/4 is unipolar and adds a rightward offset to the encoder position over a 0..5V range. With the encoder at hard left, 0..5V sweeps the full width; with the encoder at center, it sweeps from center to hard right. To get a full bipolar sweep around center, set the encoder to hard left and offset the incoming CV so that 2.5V lands at center.
+
+### Gate Overrides
+
+The trigger inputs override the position entirely, ignoring both the encoder and the pan CV for as long as they are held high:
+
+* TR 1/3 high: hard left
+* TR 2/4 high: hard right
+* Both high: dead center
+
+This is momentary rather than latching, so the position snaps back to encoder + CV control as soon as the gates are released. A zap icon appears beside the position bar while an override is active. Useful for performative hard-panning, or for slamming a wandering CV-modulated panner back to center on a downbeat.
+
+### Credits
+Authored by Eric Gao, based on Xfader by Jason Justian.

--- a/software/src/applets/Panner.h
+++ b/software/src/applets/Panner.h
@@ -25,12 +25,15 @@
 // A CV-controllable panner derived from Xfader.
 // One signal (CV1) is routed between OUT1 (left) and OUT2 (right).
 // The encoder sets a base position; CV2 (0..5V, unipolar) adds a rightward offset.
+// Gates override the position entirely: TR1 = hard left, TR2 = hard right,
+// both together = dead center.
 class Panner : public HemisphereApplet {
   APPLET_INTERFACE(Panner, "Panner", PhzIcons::mixerBal);
 
 private:
     uint8_t base_position;
-    int pos = 128;  // live position (base + CV2)
+    int pos = 128;  // live position (base + CV2, or gate override)
+    bool overridden = false;
 
     void DrawInterface() {
         const int bar_x = 14;
@@ -56,6 +59,9 @@ private:
         gfxLine(bx, 46, bx, 54);
         int px = bar_x + Proportion(pos, PANNER_MAX_VALUE, bar_w - 1);
         gfxRect(px - 1, 49, 3, 3);
+
+        // Gate override indicator
+        if (overridden) gfxIcon(bar_x + bar_w + 2, 47, ZAP_ICON);
     }
 };
 
@@ -67,10 +73,20 @@ void Panner::Controller() {
     int signal = In(0);
     int cv2 = In(1);
 
-    int offset = Proportion(constrain(cv2, 0, PANNER_CV_RANGE),
-                            PANNER_CV_RANGE, PANNER_MAX_VALUE);  // 0..5V -> rightward
+    bool left_gate = Gate(0);
+    bool right_gate = Gate(1);
+    overridden = left_gate || right_gate;
 
-    pos = constrain((int)base_position + offset, 0, PANNER_MAX_VALUE);
+    if (overridden) {
+        // Gates win over encoder and CV: both high = center, else hard to one side
+        if (left_gate && right_gate) pos = (PANNER_MAX_VALUE + 1) / 2;
+        else pos = left_gate ? 0 : PANNER_MAX_VALUE;
+    } else {
+        int offset = Proportion(constrain(cv2, 0, PANNER_CV_RANGE),
+                                PANNER_CV_RANGE, PANNER_MAX_VALUE);  // 0..5V -> rightward
+
+        pos = constrain((int)base_position + offset, 0, PANNER_MAX_VALUE);
+    }
 
     Out(0, Proportion(PANNER_MAX_VALUE - pos, PANNER_MAX_VALUE, signal));  // OUT1 = left
     Out(1, Proportion(pos, PANNER_MAX_VALUE, signal));                     // OUT2 = right
@@ -96,13 +112,13 @@ void Panner::OnDataReceive(uint64_t data) {
 
 void Panner::SetHelp() {
     //                    "-------" <-- Label size guide
-    help[HELP_DIGITAL1] = "";
-    help[HELP_DIGITAL2] = "";
+    help[HELP_DIGITAL1] = "Left";
+    help[HELP_DIGITAL2] = "Right";
     help[HELP_CV1]      = "Signal";
     help[HELP_CV2]      = "Pan CV";
     help[HELP_OUT1]     = "Left";
     help[HELP_OUT2]     = "Right";
     help[HELP_EXTRA1]   = "Enc: Position";
-    help[HELP_EXTRA2]   = "";
+    help[HELP_EXTRA2]   = "TR1+TR2: center";
     //                    "---------------------" <-- Extra text size guide
 }

--- a/software/src/applets/Panner.h
+++ b/software/src/applets/Panner.h
@@ -1,0 +1,108 @@
+// Copyright (c) 2018, Jason Justian
+// Panner variant copyright (C) 2026, Eric Gao
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#define PANNER_MAX_VALUE 255
+#define PANNER_CV_RANGE (5 * ONE_OCTAVE)  // 0..5V control range
+
+// A CV-controllable panner derived from Xfader.
+// One signal (CV1) is routed between OUT1 (left) and OUT2 (right).
+// The encoder sets a base position; CV2 (0..5V, unipolar) adds a rightward offset.
+class Panner : public HemisphereApplet {
+  APPLET_INTERFACE(Panner, "Panner", PhzIcons::mixerBal);
+
+private:
+    uint8_t base_position;
+    int pos = 128;  // live position (base + CV2)
+
+    void DrawInterface() {
+        const int bar_x = 14;
+        const int bar_w = 48;
+
+        // Output gain for each side (complementary)
+        int left_gain = PANNER_MAX_VALUE - pos;  // OUT1 / left
+        int right_gain = pos;                     // OUT2 / right
+
+        // Left output level bar
+        gfxPrint(1, 20, "L");
+        gfxFrame(bar_x, 20, bar_w, 7);
+        gfxRect(bar_x, 20, Proportion(left_gain, PANNER_MAX_VALUE, bar_w), 7);
+
+        // Right output level bar
+        gfxPrint(1, 34, "R");
+        gfxFrame(bar_x, 34, bar_w, 7);
+        gfxRect(bar_x, 34, Proportion(right_gain, PANNER_MAX_VALUE, bar_w), 7);
+
+        // Position readout: tick = encoder base, caret = live pos
+        gfxFrame(bar_x, 48, bar_w, 5);
+        int bx = bar_x + Proportion(base_position, PANNER_MAX_VALUE, bar_w - 1);
+        gfxLine(bx, 46, bx, 54);
+        int px = bar_x + Proportion(pos, PANNER_MAX_VALUE, bar_w - 1);
+        gfxRect(px - 1, 49, 3, 3);
+    }
+};
+
+FLASHMEM void Panner::Start() {
+    base_position = 128;  // center
+}
+
+void Panner::Controller() {
+    int signal = In(0);
+    int cv2 = In(1);
+
+    int offset = Proportion(constrain(cv2, 0, PANNER_CV_RANGE),
+                            PANNER_CV_RANGE, PANNER_MAX_VALUE);  // 0..5V -> rightward
+
+    pos = constrain((int)base_position + offset, 0, PANNER_MAX_VALUE);
+
+    Out(0, Proportion(PANNER_MAX_VALUE - pos, PANNER_MAX_VALUE, signal));  // OUT1 = left
+    Out(1, Proportion(pos, PANNER_MAX_VALUE, signal));                     // OUT2 = right
+}
+
+FLASHMEM void Panner::View() {
+    DrawInterface();
+}
+
+FLASHMEM void Panner::OnEncoderMove(int direction) {
+    base_position = constrain((int)base_position + direction, 0, PANNER_MAX_VALUE);
+}
+
+uint64_t Panner::OnDataRequest() {
+    uint64_t data = 0;
+    Pack(data, PackLocation {0,8}, base_position);
+    return data;
+}
+
+void Panner::OnDataReceive(uint64_t data) {
+    base_position = Unpack(data, PackLocation {0,8});
+}
+
+void Panner::SetHelp() {
+    //                    "-------" <-- Label size guide
+    help[HELP_DIGITAL1] = "";
+    help[HELP_DIGITAL2] = "";
+    help[HELP_CV1]      = "Signal";
+    help[HELP_CV2]      = "Pan CV";
+    help[HELP_OUT1]     = "Left";
+    help[HELP_OUT2]     = "Right";
+    help[HELP_EXTRA1]   = "Enc: Position";
+    help[HELP_EXTRA2]   = "";
+    //                    "---------------------" <-- Extra text size guide
+}

--- a/software/src/applets/_config.h
+++ b/software/src/applets/_config.h
@@ -81,6 +81,7 @@ using namespace HS;
 #include "MultiScale.h"
 #endif
 #include "Palimpsest.h"
+#include "Panner.h"
 #include "Pigeons.h"
 #include "PolyDiv.h"
 #include "Ponglet.h"
@@ -200,6 +201,7 @@ constexpr Registry reg = Registry<HemisphereApplet, HS::APPLET_SLOTS
     , DeclareApplet<MultiScale, 73, CAT_QUANTIZER>
 #endif
     , DeclareApplet<Palimpsest, 20, CAT_SEQUENCER>
+    , DeclareApplet<Panner, 100, CAT_UTILITY>
     , DeclareApplet<Pigeons, 71, CAT_SEQUENCER>
     , DeclareApplet<PolyDiv, 72, CAT_SEQUENCER | CAT_CLOCKING>
     , DeclareApplet<Ponglet, 99, CAT_OTHER>


### PR DESCRIPTION
## Summary

New Hemisphere applet **Panner** — a CV-controllable panner derived from Xfader.

- One signal (CV1) is routed between OUT1 (left) and OUT2 (right)
- Encoder sets the base pan position
- CV2 (0-5V, unipolar) adds a rightward offset on top of the base position
- Display shows complementary L/R output level bars, plus a position strip (tick = encoder base, caret = live CV-modulated position)

Registered in `applets/_config.h` as id 100, `CAT_UTILITY`.

## Notes

Unlike Xfader (which mixes both CV inputs into both outputs), Panner forwards only its first input, split complementarily across the two outputs — at full left, OUT2 is intentionally silent, and vice versa.

## Testing

- Built clean for T40 (`pio run -e T40`)
- Verified on Teensy 4.0 o_C hardware: encoder pans signal between outputs; CV2 sweeps the position