### PR TITLE
Fix Burst clock spacing overflow

### DIFF
--- a/software/src/applets/Burst.h
+++ b/software/src/applets/Burst.h
@@ -63,7 +63,7 @@ public:
         if (Clock(0)) {
             if (clocked) {
                 // Get a tempo, if this is the second tick or later since the last clock
-                spacing = (ticks_since_clock / number) / 17;
+                spacing = ClockCycleTicks(0) / number / 17;
                 ticks_since_clock = 0;
             } else clocked = 1;
 
@@ -227,7 +227,7 @@ private:
     // Settings
     int div; // Divide or multiply the clock tempo
     uint8_t number; // How many bursts fire at each trigger
-    uint8_t spacing; // How many ms pass between each burst
+    uint16_t spacing; // How many ms pass between each burst
     int8_t accel; // Accelleration or deceleration
     uint8_t jitter; // Randomness
     uint8_t passthru; // regular clock pulses come out, too


### PR DESCRIPTION
Fixes an overflow in the Burst applet's clocked spacing calculation.

Changes:
- Use ClockCycleTicks(0) as the clock period source instead of Burst's local ticks_since_clock counter.
- Change spacing from uint8_t to uint16_t, since Burst allows spacing up to 500 ms but uint8_t wraps values above 255.

At 120 BPM x1, this fixes NUMBER=1 from 234 ms to approximately 490 ms. NUMBER=2/3/4 remain approximately 245/163/122 ms.