### PR TITLE
T4: zero DMAMEM at boot, add a watchdog, back up the config

### DIFF
--- a/software/src/Main.cpp
+++ b/software/src/Main.cpp
@@ -51,6 +51,10 @@
 #if defined(ARDUINO_TEENSY41)
 USBHost thisUSB;
 USBHub hub1(thisUSB);
+// These MUST stay in DTCM: their member arrays are the EHCI DMA buffers,
+// and USBHost_t36's midi/ehci paths do NO cache maintenance - DTCM is
+// non-cacheable (EHCI reaches it via the CM7 AHBS backdoor), while RAM2 is
+// write-back cached and silently corrupts host MIDI both directions.
 MIDIDevice_BigBuffer usbHostMIDI[2] {
   MIDIDevice_BigBuffer(thisUSB),
   MIDIDevice_BigBuffer(thisUSB)
@@ -218,13 +222,93 @@ void BootMenu() {
 }
 #endif
 
+// ---------------------------------------------------------------------------
+// Crash forensics + hardware watchdog (T4.x)
+// ---------------------------------------------------------------------------
+#if defined(__IMXRT1062__)
+// The core never zeroes .bss.dma (DMAMEM is documented as uninitialized), so
+// C++ objects placed there boot with garbage in any member their constructor
+// doesn't touch - USBHost_t36 state machines rely on bss-zero and lock up.
+// Zero the section here: ResetHandler calls this hook after the DTCM bss
+// clear and BEFORE __libc_init_array (C++ ctors). .bss.dma is the first
+// section in RAM2 (origin 0x20200000) and ends at _heap_start per the .ld.
+extern unsigned long _heap_start;
+extern "C" FLASHMEM void startup_middle_hook(void) {
+  memset((void *)0x20200000, 0, (uint32_t)&_heap_start - 0x20200000u);
+}
+
+// Capture CrashReport text at boot so it can be appended to CRASH.LOG once
+// LittleFS is mounted (the Serial print is gone if nobody was watching).
+// buffer lives in RAM2 (DMAMEM) - DTCM stack headroom is precious
+static DMAMEM char crash_buf[1024];
+class BufferPrint : public Print {
+public:
+  char *buf = crash_buf;
+  size_t len = 0;
+  size_t write(uint8_t c) override {
+    if (len < sizeof(crash_buf) - 1) { buf[len++] = c; buf[len] = 0; return 1; }
+    return 0;
+  }
+};
+static BufferPrint crash_capture;
+
+// Reset cause, captured then cleared at boot: SRSR bits are sticky w1c and
+// would otherwise show every cause since the last power-on, forever.
+static uint32_t boot_srsr = 0;
+
+// WDOG1: 128s timeout, fed only from loop(). Long enough that the slowest
+// legitimate blocking op (a full LittleFS format) rarely trips it; a hard
+// loop() hang reboots instead of bricking the module until power-cycle.
+// Armed at the END of setup() so interactive boot flows (BootMenu,
+// ConfirmReset) can block indefinitely.
+static bool watchdog_armed = false;
+FLASHMEM static void watchdog_arm() {
+  // the core never ungates WDOG1's clock ("WDOG1 requires CCM_CCGR3_WDOG1"
+  // per imxrt.h) - touching its registers without this bus-faults
+  CCM_CCGR3 |= CCM_CCGR3_WDOG1(CCM_CCGR_ON);
+  asm volatile("dsb");
+  // PDE (set at reset) is a one-shot 16s power-down counter that asserts
+  // reset unless cleared - with the clock just ungated it would fire ~16s
+  // after arming and masquerade as a watchdog timeout
+  WDOG1_WMCR = 0;
+  WDOG1_WCR = (uint16_t)(255u << 8)  // WT: (255+1)*0.5s = 128s
+            | WDOG_WCR_WDE | WDOG_WCR_SRS | WDOG_WCR_WDA
+            | WDOG_WCR_WDBG | WDOG_WCR_WDZST;
+  watchdog_armed = true;
+}
+static inline void watchdog_feed() {
+  WDOG1_WSR = 0x5555;
+  WDOG1_WSR = 0xAAAA;
+}
+
+// A full LittleFS format can exceed 128s worst-case (flash sector erase is
+// 400ms MAX) - the one legitimate loop-blocking op longer than the
+// watchdog. Feed from a timer for its duration only.
+static IntervalTimer wdog_format_feeder;
+static void watchdog_feed_isr() { watchdog_feed(); }  // ISR: stays in ITCM
+FLASHMEM static void watchdog_feed_during(void (*op)()) {
+  wdog_format_feeder.begin(watchdog_feed_isr, 1000000);  // 1s
+  op();
+  wdog_format_feeder.end();
+}
+#endif
+
 void setup() {
   delay(50);
+#if defined(__IMXRT1062__)
+  boot_srsr = SRC_SRSR;
+  SRC_SRSR = boot_srsr;  // w1c: next boot reports only its own cause
+#endif
   Serial.begin(9600);
 
   if (CrashReport) {
     while (!Serial && millis() < 3000) ; // wait
     Serial.println(CrashReport);
+#if defined(__IMXRT1062__)
+    // stash the report so it can be appended to CRASH.LOG once the
+    // filesystem is up (console prints vanish when nobody is watching)
+    crash_capture.print(CrashReport);
+#endif
     delay(1500);
   }
 
@@ -349,6 +433,29 @@ void setup() {
   // initialize LittleFS for config files
   PhzConfig::Init();
 
+#if defined(__IMXRT1062__)
+  // Written here, straight after the mount: reading CrashReport at the top of
+  // setup() clears it, so anything that dies between there and the first write
+  // loses the report for good. This is the earliest point a file can exist.
+  // append any captured crash report to CRASH.LOG (rotate at 8KB)
+  if (crash_capture.len) {
+    File cl = PhzConfig::myfs.open("CRASH.LOG", FILE_READ);
+    const bool rotate = cl && cl.size() > 8192;
+    if (cl) cl.close();
+    if (rotate) {  // keep one generation of history instead of deleting
+      PhzConfig::myfs.remove("CRASH.OLD");
+      PhzConfig::myfs.rename("CRASH.LOG", "CRASH.OLD");
+    }
+    cl = PhzConfig::myfs.open("CRASH.LOG", FILE_WRITE);  // append
+    if (cl) {
+      cl.printf("--- boot @ %lu ms ---\n", millis());
+      cl.write((const uint8_t *)crash_capture.buf, crash_capture.len);
+      cl.close();
+      Serial.println("CrashReport appended to CRASH.LOG");
+    }
+  }
+#endif
+
   // Display loading splash screen and optional calibration
   bool reset_settings = false;
   ui_mode = OC::ui.Splashscreen(reset_settings, 0);
@@ -367,6 +474,19 @@ void setup() {
 
   // use default global config file in LFS
   bool firstrun = !PhzConfig::load_config();
+#ifdef __IMXRT1062__
+  if (firstrun) {
+    // GLOBALS.CFG missing/corrupt: try the boot-time backup before the
+    // ConfirmReset flow gets a chance to threaten a factory wipe.
+    if (PhzConfig::load_config(PhzConfig::BACKUP_FILENAME)) {
+      Serial.println("CONFIG: GLOBALS.CFG bad; restored from GLOBALS.BAK");
+      PhzConfig::save_config();  // re-materialize the primary from memory
+      firstrun = false;
+    }
+  } else {
+    PhzConfig::backup_config();  // known-good primary: refresh the backup
+  }
+#endif
 
   // initialize apps
   OC::app_switcher.Init(reset_settings || firstrun);
@@ -378,6 +498,13 @@ void setup() {
     OC::start_calibration();
 
   OC::app_switcher.current_app()->DispatchAppEvent(OC::APP_EVENT_RESUME);
+
+#if defined(__IMXRT1062__)
+  // last: everything interactive that can legitimately block forever is
+  // behind us, and loop() takes over feeding from here
+  watchdog_arm();
+  SERIAL_PRINTLN("* WDOG1 armed (128s, fed from loop)");
+#endif
 
   SERIAL_PRINTLN("[End of setup()]");
 }
@@ -393,6 +520,9 @@ void FASTRUN loop() {
   uint32_t last_redraw_time = 0;
 
   while (true) {
+#if defined(__IMXRT1062__)
+    watchdog_feed();  // a wedged loop() now reboots instead of bricking
+#endif
 #if defined(ARDUINO_TEENSY41)
     thisUSB.Task();
 #endif
@@ -520,7 +650,9 @@ void FASTRUN loop() {
             break;
           case 'F':
             Serial.println("!! ERASING ALL FILES on LittleFS !!");
-            PhzConfig::eraseFiles();
+            // a worst-case format can outlive the 128s watchdog, so feed it
+            // from a timer for the duration
+            watchdog_feed_during([] { PhzConfig::eraseFiles(); });
             break;
 #endif
 

--- a/software/src/PhzConfig.cpp
+++ b/software/src/PhzConfig.cpp
@@ -286,6 +286,26 @@ bool load_config(const char* filename, FS &fs)
 }
 
 FLASHMEM
+bool backup_config()
+{
+  File src = myfs.open(CONFIG_FILENAME, FILE_READ);
+  if (!src) return false;
+  myfs.remove(BACKUP_FILENAME);
+  File dst = myfs.open(BACKUP_FILENAME, FILE_WRITE_BEGIN);
+  if (!dst) { src.close(); return false; }
+  uint8_t buf[256];
+  int n;
+  bool ok = true;
+  while ((n = src.read(buf, sizeof(buf))) > 0) {
+    if (dst.write(buf, n) != (size_t)n) { ok = false; break; }
+  }
+  src.close();
+  dst.close();
+  if (!ok) myfs.remove(BACKUP_FILENAME);  // no partial backups
+  return ok;
+}
+
+FLASHMEM
 void listFiles(FS &fs)
 {
   Serial.print("\n     Space Used = ");

--- a/software/src/PhzConfig.h
+++ b/software/src/PhzConfig.h
@@ -31,6 +31,12 @@ namespace PhzConfig {
   bool getData(KEY key, VALUE &value);
   void deleteData(KEY key);
 
+  // Copy GLOBALS.CFG -> GLOBALS.BAK (called once per boot after a good
+  // load, so a corrupt primary can be recovered instead of blocking boot
+  // at the ConfirmReset prompt). Returns false on any I/O failure.
+  bool backup_config();
+  const char * const BACKUP_FILENAME = "GLOBALS.BAK";
+
   void printDirectory(FS &fs = myfs);
   void printDirectory(File dir, int numSpaces);
   void printSpaces(int num);


### PR DESCRIPTION
Squashed to one commit, down to the three things you said were worth having.

- `startup_middle_hook()` zeroes `.bss.dma`. The core leaves DMAMEM uninitialized, so objects placed there boot with garbage in any member the constructor doesn't set, and USBHost_t36's state machines wedge on it.
- WDOG1 at 128s, fed from `loop()`, armed at the end of `setup()` so BootMenu and ConfirmReset can still block. A LittleFS format can outlive the timeout, so it's timer-fed for its duration.
- `GLOBALS.CFG` is copied to `GLOBALS.BAK` when it loads cleanly, and restored from the copy when it doesn't, instead of threatening a factory reset.

On the boot loop: `CrashReport` is now written to `CRASH.LOG` immediately after the filesystem mounts. Reading the report clears it, and the old code wrote it 150 lines later, so anything that died in between lost it. That's why you only ever saw one entry.

Dropped since the first version: the FLASHMEM work, the console hardening, the `SwitchToApp` helper, and the LittleFS partition change. 3 files now instead of 9.

Builds T41, T41_audio, T40, nlm_T40, nlm_hoc_T40. Not tested on 3.x — those targets don't build on main for me, `'PhzConfig' has not been declared` in HemisphereApplet.h and Main.cpp, before any of my changes.
