### PR TITLE
Reinstate VectorMod

### DIFF
--- a/software/src/hemisphere_config.h
+++ b/software/src/hemisphere_config.h
@@ -257,7 +257,7 @@ AppletRegistry reg{
     DeclareApplet<Stairs>{61, 0x01},
     DeclareApplet<VectorEG>{52, 0x01},
     DeclareApplet<VectorLFO>{49, 0x01},
-    //DeclareApplet<VectorMod>{53, 0x01}, // awkward middle child
+    DeclareApplet<VectorMod>{53, 0x01},
     DeclareApplet<VectorMorph>{54, 0x01},
 #endif
 #ifdef APPLETS_LOGIC_UTILITY


### PR DESCRIPTION
Have created a fork in order to reinstate the VectorMod applet in the hemisphere_config.h file